### PR TITLE
varargs subscription

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/Consumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/Consumer.java
@@ -43,6 +43,13 @@ public interface Consumer<K, X> extends Closeable {
    *
    * @param topics topics to subscribe
    */
+  void subscribe(String... topics);
+
+  /**
+   * Subscribe.
+   *
+   * @param topics topics to subscribe
+   */
   void subscribe(Collection<String> topics);
 
   /**

--- a/src/main/java/io/github/eocqrs/kafka/consumer/KfConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/consumer/KfConsumer.java
@@ -27,6 +27,7 @@ import io.github.eocqrs.kafka.ConsumerSettings;
 import io.github.eocqrs.kafka.Dataized;
 import io.github.eocqrs.kafka.data.KfData;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.cactoos.list.ListOf;
 
 import java.time.Duration;
 import java.util.ArrayList;
@@ -65,6 +66,11 @@ public final class KfConsumer<K, X> implements Consumer<K, X> {
    */
   public KfConsumer(final ConsumerSettings<K, X> settings) {
     this(settings.consumer());
+  }
+
+  @Override
+  public void subscribe(final String... topics) {
+    this.subscribe(new ListOf<>(topics));
   }
 
   @Override

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
@@ -43,6 +43,11 @@ import java.util.List;
 public final class FkConsumer<K, X> implements Consumer<K, X> {
 
   @Override
+  public void subscribe(final String... topics) {
+    throw new UnsupportedOperationException("#subscribe()");
+  }
+
+  @Override
   public void subscribe(final Collection<String> topics) {
     throw new UnsupportedOperationException("#subscribe()");
   }

--- a/src/test/java/io/github/eocqrs/kafka/consumer/KfConsumerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/consumer/KfConsumerTest.java
@@ -59,10 +59,10 @@ final class KfConsumerTest {
     Mockito.when(settings.consumer()).thenReturn(consumer);
     final Consumer<String, String> underTest = new KfConsumer<>(settings);
     assertDoesNotThrow(
-      () ->
-        underTest.subscribe(
-          new ListOf<>("transactions-info")
-        )
+      () -> {
+        underTest.subscribe(new ListOf<>("transactions-info"));
+        underTest.subscribe("transactions-info");
+      }
     );
     assertDoesNotThrow(
       underTest::close

--- a/src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java
@@ -1,0 +1,70 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.fake;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import java.time.Duration;
+import java.util.ArrayList;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+/**
+ * Test case for {@link FkConsumer}.
+ *
+ * @author Ivan Ivanchuck (l3r8y@duck.com)
+ * @since 0.0.3
+ */
+final class FkConsumerTest {
+
+    @Test
+    void createsFakeConsumer() {
+      final FkConsumer<String, String> consumer = new FkConsumer<>();
+      MatcherAssert.assertThat(consumer, Matchers.is(Matchers.notNullValue()));
+      assertThrows(
+        UnsupportedOperationException.class,
+        () -> consumer.subscribe("123")
+      );
+      assertThrows(
+        UnsupportedOperationException.class,
+        () -> consumer.subscribe(new ArrayList<>(0))
+      );
+      assertThrows(
+        UnsupportedOperationException.class,
+        () -> consumer.iterate("123", Duration.ofMillis(100L))
+      );
+      assertThrows(
+        UnsupportedOperationException.class,
+        () -> consumer.iterate("123", Duration.ofMillis(100L))
+      );
+      assertThrows(
+        UnsupportedOperationException.class,
+        consumer::close
+      );
+    }
+
+}


### PR DESCRIPTION
closes #258 

@h1alexbel take a look, please

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new method to the `Consumer` interface and implements it in the `FkConsumer` class, while updating its tests. It also modifies the `KfConsumer` class to simplify its logic. 

### Detailed summary
- Added `void subscribe(String... topics)` to `Consumer` interface
- Implemented `subscribe` method in `FkConsumer` to throw an `UnsupportedOperationException`
- Updated `FkConsumer` tests to reflect this change
- Modified `KfConsumer` class to wrap `subscribe(String... topics)` with `subscribe(Collection<String> topics)`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->