### PR TITLE
Add better logs

### DIFF
--- a/src/it/producer-consumer-api/pom.xml
+++ b/src/it/producer-consumer-api/pom.xml
@@ -43,10 +43,14 @@ SOFTWARE.
   </properties>
   <dependencies>
     <dependency>
-      <groupId>@project.groupId@</groupId>
-      <artifactId>@project.artifactId@</artifactId>
-      <version>@project.version@</version>
-      <scope>test</scope>
+      <groupId>io.github.eo-cqrs</groupId>
+      <artifactId>eo-kafka</artifactId>
+      <version>1.0-SNAPSHOT</version>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>2.0.7</version>
     </dependency>
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/src/it/producer-consumer-api/pom.xml
+++ b/src/it/producer-consumer-api/pom.xml
@@ -43,9 +43,10 @@ SOFTWARE.
   </properties>
   <dependencies>
     <dependency>
-      <groupId>io.github.eo-cqrs</groupId>
-      <artifactId>eo-kafka</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>@project.artifactId@</artifactId>
+      <version>@project.version@</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>


### PR DESCRIPTION
I've added bit better logging inside of container and also refactored the integration test, maybe it's will be helpful for solving #266 

@h1alexbel take a look, please

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for SLF4J logging and improves the KafkaContainer usage in the EntryTest class.

### Detailed summary
- Added dependency to support SLF4J logging
- Removed unused container import
- Improved KafkaContainer usage in EntryTest class:
  - Added `@BeforeAll` method to start the container and set `servers` field
  - Changed `KAFKA_CREATE_TOPICS` env variable to create a specific topic
  - Added `withReuse(true)` to reuse the container instance
  - Added `withLogConsumer` to redirect container logs to SLF4J logger

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->