### PR TITLE
Change publicity level of KfCustomer, TextXpath

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/xml/KfCustomer.java
+++ b/src/main/java/io/github/eocqrs/kafka/xml/KfCustomer.java
@@ -28,7 +28,7 @@ package io.github.eocqrs.kafka.xml;
  * @author Ivan Ivanchuk (l3r8y@duck.com)
  * @since 0.0.2
  */
-public enum KfCustomer {
+enum KfCustomer {
   /**
    * The consumer.
    */

--- a/src/main/java/io/github/eocqrs/kafka/xml/TextXpath.java
+++ b/src/main/java/io/github/eocqrs/kafka/xml/TextXpath.java
@@ -30,7 +30,7 @@ import lombok.RequiredArgsConstructor;
  * @since 0.0.0
  */
 @RequiredArgsConstructor
-public final class TextXpath {
+final class TextXpath {
 
   /**
    * The XML file.


### PR DESCRIPTION
closes #269 

@h1alexbel take a look, please 

if you know some classes that we can hide, list them, I'll fix

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes unnecessary access modifiers in two Java classes.

### Detailed summary
- Removed `public` access modifier from `KfCustomer` enum.
- Removed `public` access modifier from `TextXpath` class.
- No changes were made to functionality or behavior of the code.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->