### PR TITLE
consumer subscribes with ConsumerRebalanceListener

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/Consumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/Consumer.java
@@ -26,6 +26,7 @@ import java.io.Closeable;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 
 /**
  * Consumer.
@@ -51,6 +52,14 @@ public interface Consumer<K, X> extends Closeable {
    * @param topics topics to subscribe
    */
   void subscribe(Collection<String> topics);
+
+  /**
+   * Subscribe.
+   *
+   * @param listener rebalance listener
+   * @param topics   topics to subscribe
+   */
+  void subscribe(ConsumerRebalanceListener listener, String... topics);
 
   /**
    * Dataized.

--- a/src/main/java/io/github/eocqrs/kafka/consumer/KfConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/consumer/KfConsumer.java
@@ -26,6 +26,7 @@ import io.github.eocqrs.kafka.Consumer;
 import io.github.eocqrs.kafka.ConsumerSettings;
 import io.github.eocqrs.kafka.Dataized;
 import io.github.eocqrs.kafka.data.KfData;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.cactoos.list.ListOf;
 
@@ -76,6 +77,11 @@ public final class KfConsumer<K, X> implements Consumer<K, X> {
   @Override
   public void subscribe(final Collection<String> topics) {
     this.origin.subscribe(topics);
+  }
+
+  @Override
+  public void subscribe(final ConsumerRebalanceListener listener, final String... topics) {
+    this.origin.subscribe(new ListOf<>(topics), listener);
   }
 
   /**

--- a/src/main/java/io/github/eocqrs/kafka/consumer/KfConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/consumer/KfConsumer.java
@@ -80,7 +80,8 @@ public final class KfConsumer<K, X> implements Consumer<K, X> {
   }
 
   @Override
-  public void subscribe(final ConsumerRebalanceListener listener, final String... topics) {
+  public void subscribe(final ConsumerRebalanceListener listener,
+                        final String... topics) {
     this.origin.subscribe(new ListOf<>(topics), listener);
   }
 

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
@@ -31,6 +31,7 @@ import io.github.eocqrs.kafka.Dataized;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 
 /**
  * Fake Consumer.
@@ -49,6 +50,11 @@ public final class FkConsumer<K, X> implements Consumer<K, X> {
 
   @Override
   public void subscribe(final Collection<String> topics) {
+    throw new UnsupportedOperationException("#subscribe()");
+  }
+
+  @Override
+  public void subscribe(final ConsumerRebalanceListener listener, final String... topics) {
     throw new UnsupportedOperationException("#subscribe()");
   }
 

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
@@ -54,7 +54,8 @@ public final class FkConsumer<K, X> implements Consumer<K, X> {
   }
 
   @Override
-  public void subscribe(final ConsumerRebalanceListener listener, final String... topics) {
+  public void subscribe(final ConsumerRebalanceListener listener,
+                        final String... topics) {
     throw new UnsupportedOperationException("#subscribe()");
   }
 

--- a/src/test/java/io/github/eocqrs/kafka/consumer/KfConsumerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/consumer/KfConsumerTest.java
@@ -32,7 +32,10 @@ import io.github.eocqrs.kafka.parameters.KfFlexible;
 import io.github.eocqrs.kafka.parameters.KfParams;
 import io.github.eocqrs.kafka.parameters.ValueDeserializer;
 import io.github.eocqrs.kafka.xml.KfXmlFlexible;
+import java.util.Collection;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.common.TopicPartition;
 import org.cactoos.list.ListOf;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -55,13 +58,22 @@ final class KfConsumerTest {
   void subscribes(
     @Mock final ConsumerSettings<String, String> settings,
     @Mock final KafkaConsumer<String, String> consumer
-    ) {
+  ) {
     Mockito.when(settings.consumer()).thenReturn(consumer);
     final Consumer<String, String> underTest = new KfConsumer<>(settings);
     assertDoesNotThrow(
       () -> {
         underTest.subscribe(new ListOf<>("transactions-info"));
         underTest.subscribe("transactions-info");
+        underTest.subscribe(new ConsumerRebalanceListener() {
+          @Override
+          public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
+          }
+
+          @Override
+          public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
+          }
+        }, "transactions-info");
       }
     );
     assertDoesNotThrow(

--- a/src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java
@@ -24,6 +24,9 @@
 
 package io.github.eocqrs.kafka.fake;
 
+import java.util.Collection;
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.common.TopicPartition;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
@@ -41,30 +44,42 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
  */
 final class FkConsumerTest {
 
-    @Test
-    void createsFakeConsumer() {
-      final FkConsumer<String, String> consumer = new FkConsumer<>();
-      MatcherAssert.assertThat(consumer, Matchers.is(Matchers.notNullValue()));
-      assertThrows(
-        UnsupportedOperationException.class,
-        () -> consumer.subscribe("123")
-      );
-      assertThrows(
-        UnsupportedOperationException.class,
-        () -> consumer.subscribe(new ArrayList<>(0))
-      );
-      assertThrows(
-        UnsupportedOperationException.class,
-        () -> consumer.iterate("123", Duration.ofMillis(100L))
-      );
-      assertThrows(
-        UnsupportedOperationException.class,
-        () -> consumer.iterate("123", Duration.ofMillis(100L))
-      );
-      assertThrows(
-        UnsupportedOperationException.class,
-        consumer::close
-      );
-    }
+  @Test
+  void createsFakeConsumer() {
+    final FkConsumer<String, String> consumer = new FkConsumer<>();
+    MatcherAssert.assertThat(consumer, Matchers.is(Matchers.notNullValue()));
+    assertThrows(
+      UnsupportedOperationException.class,
+      () -> consumer.subscribe("123")
+    );
+    assertThrows(
+      UnsupportedOperationException.class,
+      () -> consumer.subscribe(new ArrayList<>(0))
+    );
+    assertThrows(
+      UnsupportedOperationException.class,
+      () -> consumer.subscribe(new ConsumerRebalanceListener() {
+        @Override
+        public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
+        }
+
+        @Override
+        public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
+        }
+      }, "fake")
+    );
+    assertThrows(
+      UnsupportedOperationException.class,
+      () -> consumer.iterate("123", Duration.ofMillis(100L))
+    );
+    assertThrows(
+      UnsupportedOperationException.class,
+      () -> consumer.iterate("123", Duration.ofMillis(100L))
+    );
+    assertThrows(
+      UnsupportedOperationException.class,
+      consumer::close
+    );
+  }
 
 }


### PR DESCRIPTION
closes #261

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new `subscribe` method to the `Consumer` interface that takes a `ConsumerRebalanceListener` as its first argument. It also updates the `KfConsumer` class to use this new method and adds tests for it.

### Detailed summary
- Added a new `subscribe` method to the `Consumer` interface that takes a `ConsumerRebalanceListener` as its first argument
- Updated the `KfConsumer` class to use the new `subscribe` method
- Added tests for the new `subscribe` method in the `KfConsumerTest` class
- Added a test for the new `subscribe` method in the `FkConsumerTest` class

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->