### PR TITLE
ITCase puzzle off

### DIFF
--- a/src/test/java/io/github/eocqrs/kafka/producer/KfProducerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/producer/KfProducerTest.java
@@ -38,15 +38,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
 /**
  * Test case for {@link io.github.eocqrs.kafka.producer.KfProducer}
  *
  * @since 0.0.0
- */
-
-/**
- * @todo #47:45m/DEV Consumer Producer communication.
- * We have to create an ITCase for communication between Consumer and Producer.
  */
 @ExtendWith(MockitoExtension.class)
 final class KfProducerTest {


### PR DESCRIPTION
ITCase already created, so, puzzle can be removed from source code

closes #111 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR removes a to-do comment in `KfProducerTest.java`. 

### Detailed summary
- Removes a to-do comment regarding creating an ITCase for communication between Consumer and Producer.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->