### PR TITLE
Future `send`

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/Producer.java
+++ b/src/main/java/io/github/eocqrs/kafka/Producer.java
@@ -23,12 +23,15 @@
 package io.github.eocqrs.kafka;
 
 import java.io.Closeable;
+import java.util.concurrent.Future;
+import org.apache.kafka.clients.producer.RecordMetadata;
 
 /*
-* @todo #204:DEV/30min Make send return CompletableFuture.
-*  A more correct way to implement the #send
-*  method should have the return type CompletableFuture
-* */
+ * @todo #204:DEV/30min Make send return CompletableFuture.
+ *  A more correct way to implement the #send
+ *  method should have the return type CompletableFuture
+ * */
+
 /**
  * Producer.
  *
@@ -44,6 +47,7 @@ public interface Producer<K, X> extends Closeable {
    *
    * @param key  message key
    * @param data data wrapper to process
+   * @return Future with RecordMetadata.
    */
-  void send(K key, Data<X> data);
+  Future<RecordMetadata> send(K key, Data<X> data);
 }

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
@@ -27,6 +27,8 @@ package io.github.eocqrs.kafka.fake;
 
 import io.github.eocqrs.kafka.Data;
 import io.github.eocqrs.kafka.Producer;
+import java.util.concurrent.Future;
+import org.apache.kafka.clients.producer.RecordMetadata;
 
 /**
  * Fake Producer.
@@ -39,7 +41,7 @@ import io.github.eocqrs.kafka.Producer;
 public final class FkProducer<K, X> implements Producer<K, X> {
 
   @Override
-  public void send(final K key, final Data<X> message) {
+  public Future<RecordMetadata> send(final K key, final Data<X> message) {
     throw new UnsupportedOperationException("#send()");
   }
 

--- a/src/main/java/io/github/eocqrs/kafka/producer/KfCallback.java
+++ b/src/main/java/io/github/eocqrs/kafka/producer/KfCallback.java
@@ -33,10 +33,6 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
-/*
- * @todo #204:DEV/30min Integration test for `KfCallback`
- *  Create an integration test to test the callback mechanism.
- * */
 /**
  * Kafka Producer with callback, decorator for {@link Producer}.
  *

--- a/src/main/java/io/github/eocqrs/kafka/producer/KfCallback.java
+++ b/src/main/java/io/github/eocqrs/kafka/producer/KfCallback.java
@@ -27,9 +27,11 @@ package io.github.eocqrs.kafka.producer;
 import io.github.eocqrs.kafka.Data;
 import io.github.eocqrs.kafka.Producer;
 import io.github.eocqrs.kafka.ProducerSettings;
+import java.util.concurrent.Future;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 
 /*
  * @todo #204:DEV/30min Integration test for `KfCallback`
@@ -80,8 +82,8 @@ public final class KfCallback<K, X> implements Producer<K, X> {
   }
 
   @Override
-  public void send(final K key, final Data<X> data) {
-    this.origin.send(
+  public Future<RecordMetadata> send(final K key, final Data<X> data) {
+    return this.origin.send(
       new ProducerRecord<>(
         data.topic(),
         data.partition(),

--- a/src/main/java/io/github/eocqrs/kafka/producer/KfProducer.java
+++ b/src/main/java/io/github/eocqrs/kafka/producer/KfProducer.java
@@ -19,13 +19,16 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
+
 package io.github.eocqrs.kafka.producer;
 
 import io.github.eocqrs.kafka.Data;
 import io.github.eocqrs.kafka.Producer;
 import io.github.eocqrs.kafka.ProducerSettings;
+import java.util.concurrent.Future;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.clients.producer.RecordMetadata;
 
 /**
  * Kafka Producer.
@@ -63,8 +66,8 @@ public final class KfProducer<K, X> implements Producer<K, X> {
   }
 
   @Override
-  public void send(final K key, final Data<X> data) {
-    this.origin.send(
+  public Future<RecordMetadata> send(final K key, final Data<X> data) {
+    return this.origin.send(
       new ProducerRecord<>(
         data.topic(),
         data.partition(),

--- a/src/test/java/io/github/eocqrs/kafka/producer/KfCallbackTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/producer/KfCallbackTest.java
@@ -32,6 +32,7 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -56,12 +57,18 @@ final class KfCallbackTest {
             MatcherAssert.assertThat(
               recordMetadata.topic(),
               Matchers.equalTo("fake-topic")
-          )
+            )
         )
     ) {
-      final Future<RecordMetadata> future = producer.send(
-        "fake-key",
-        new KfData<>("fake-data", "fake-topic", 101)
+      Assertions.assertDoesNotThrow(
+        () -> producer.send(
+          "fake-key",
+          new KfData<>(
+            "fake-data",
+            "fake-topic",
+            101
+          )
+        )
       );
     }
   }
@@ -83,9 +90,15 @@ final class KfCallbackTest {
             )
         )
     ) {
-      final Future<RecordMetadata> future = producer.send(
-        "fake-key",
-        new KfData<>("fake-data", "fake-topic", 101)
+      Assertions.assertDoesNotThrow(
+        () -> producer.send(
+          "fake-key",
+          new KfData<>(
+            "fake-data",
+            "fake-topic",
+            101
+          )
+        )
       );
     }
   }

--- a/src/test/java/io/github/eocqrs/kafka/producer/KfCallbackTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/producer/KfCallbackTest.java
@@ -26,6 +26,7 @@ package io.github.eocqrs.kafka.producer;
 
 import io.github.eocqrs.kafka.ProducerSettings;
 import io.github.eocqrs.kafka.data.KfData;
+import java.util.concurrent.Future;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -58,7 +59,7 @@ final class KfCallbackTest {
           )
         )
     ) {
-      producer.send(
+      final Future<RecordMetadata> future = producer.send(
         "fake-key",
         new KfData<>("fake-data", "fake-topic", 101)
       );
@@ -82,7 +83,7 @@ final class KfCallbackTest {
             )
         )
     ) {
-      producer.send(
+      final Future<RecordMetadata> future = producer.send(
         "fake-key",
         new KfData<>("fake-data", "fake-topic", 101)
       );


### PR DESCRIPTION
closes #265 
@l3r8yJ, take a look, please

<!-- start pr-codex -->

---

## PR-Codex overview
This PR makes changes to the `Producer` interface and its implementations to return a `Future<RecordMetadata>` instead of `void` when calling the `send` method. 

### Detailed summary
- Changes the `Producer` interface to return a `Future<RecordMetadata>` instead of `void` when calling the `send` method.
- Updates the `FkProducer` and `KfProducer` classes to reflect the new interface.
- Adds the `RecordMetadata` import to the relevant classes.
- Removes the `@todo` comments related to the `send` method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->