### PR TITLE
Add KfCallback integration test

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/producer/KfCallback.java
+++ b/src/main/java/io/github/eocqrs/kafka/producer/KfCallback.java
@@ -33,10 +33,6 @@ import org.apache.kafka.clients.producer.KafkaProducer;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 
-/*
- * @todo #204:DEV/30min Integration test for `KfCallback`
- *  Create an integration test to test the callback mechanism.
- * */
 /**
  * Kafka Producer with callback, decorator for {@link KafkaProducer}.
  *

--- a/src/main/java/io/github/eocqrs/kafka/producer/KfCallback.java
+++ b/src/main/java/io/github/eocqrs/kafka/producer/KfCallback.java
@@ -38,7 +38,7 @@ import org.apache.kafka.clients.producer.RecordMetadata;
  *  Create an integration test to test the callback mechanism.
  * */
 /**
- * Kafka Producer with callback, decorator for {@link Producer}.
+ * Kafka Producer with callback, decorator for {@link KafkaProducer}.
  *
  * @param <K> The key
  * @param <X> The value


### PR DESCRIPTION
closes #266 

@h1alexbel take a look, please

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a callback mechanism to the Kafka producer and includes an integration test. 

### Detailed summary
- Added `KfCallback` class to implement the callback mechanism for KafkaProducer.
- Added `createsProducerWithCallback` method to `EntryTest` to test the callback mechanism.
- Removed `@todo` comments from `KfCallback` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->