### PR TITLE
KfCallback, `subscribe` with ConsumerRebalanceListener README refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,19 @@ try (
     }
   }
 ```
-Also, you can `subscribe` with 
+Also, you can `subscribe` with [ConsumerRebalanceListener](https://kafka.apache.org/24/javadoc/index.html?org/apache/kafka/clients/consumer/ConsumerRebalanceListener.html):
+```java
+consumer.subscribe(new ConsumerRebalanceListener() {
+    @Override
+    public void onPartitionsRevoked(final Collection<TopicPartition> partitions) {
+    }
+    @Override
+    public void onPartitionsAssigned(final Collection<TopicPartition> partitions) {
+    }
+  }, "<your topic>");
+ }
+);
+```
 
 ## Config API
 | Kafka Property                  | eo-kafka API                                                                                                                                                    | XML tag

--- a/README.md
+++ b/README.md
@@ -128,6 +128,26 @@ try (final Producer<String, String> producer = ...) {
 }
 ```
 
+Also, you can create [KfCallback](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/producer/KfCallback.java), Kafka Producer with Async [Callback](https://kafka.apache.org/26/javadoc/org/apache/kafka/clients/producer/Callback.html) support:
+```java
+final Producer<String, String> producer =
+  new KfCallback<>(
+    new KfFlexible<>(
+      new KfProducerParams(
+        new KfParams(
+          // producer params
+        )
+      )
+    ),
+    new Callback() {
+      @Override
+      public void onCompletion(final RecordMetadata meta, final Exception ex) {
+        // logic
+      }
+    }
+);    
+```
+
 ## Consumer API
 To create Kafka Consumer you can wrap original [KafkaConsumer](https://kafka.apache.org/23/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html):
 ```java
@@ -194,6 +214,7 @@ try (
     }
   }
 ```
+Also, you can `subscribe` with 
 
 ## Config API
 | Kafka Property                  | eo-kafka API                                                                                                                                                    | XML tag

--- a/src/test/java/io/github/eocqrs/kafka/producer/KfCallbackTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/producer/KfCallbackTest.java
@@ -26,10 +26,7 @@ package io.github.eocqrs.kafka.producer;
 
 import io.github.eocqrs.kafka.ProducerSettings;
 import io.github.eocqrs.kafka.data.KfData;
-import java.util.concurrent.Future;
-import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.RecordMetadata;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
closes #278, #280

peer review: @l3r8yJ, take a look, please

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for Kafka Producer with Async Callback and Kafka Consumer with ConsumerRebalanceListener. It also includes updates to the Config API.

### Detailed summary
- Added support for Kafka Producer with Async Callback
- Added support for Kafka Consumer with ConsumerRebalanceListener
- Updated Config API

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->