### PR TITLE
Consumer Unsubscribes

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/Consumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/Consumer.java
@@ -26,6 +26,7 @@ import java.io.Closeable;
 import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
+
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 
 /**
@@ -69,4 +70,9 @@ public interface Consumer<K, X> extends Closeable {
    * @return Dataized polled data.
    */
   List<Dataized<X>> iterate(String topic, Duration timeout);
+
+  /**
+   * Unsubscribe.
+   */
+  void unsubscribe();
 }

--- a/src/main/java/io/github/eocqrs/kafka/consumer/KfConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/consumer/KfConsumer.java
@@ -111,6 +111,11 @@ public final class KfConsumer<K, X> implements Consumer<K, X> {
   }
 
   @Override
+  public void unsubscribe() {
+    this.origin.unsubscribe();
+  }
+
+  @Override
   public void close() {
     this.origin.close();
   }

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
@@ -80,7 +80,7 @@ public final class FkConsumer<K, X> implements Consumer<K, X> {
   }
 
   /*
-   * @todo #54:60m/DEV Fake close is not implemented
+   * @todo #54:60m/DEV Fake consumer close is not implemented
    */
   @Override
   public void close() {

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
@@ -65,6 +65,11 @@ public final class FkConsumer<K, X> implements Consumer<K, X> {
   }
 
   @Override
+  public void unsubscribe() {
+    throw new UnsupportedOperationException("#unsubscribe()");
+  }
+
+  @Override
   public void close() {
     throw new UnsupportedOperationException("#close()");
   }

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
@@ -54,7 +54,8 @@ public final class FkConsumer<K, X> implements Consumer<K, X> {
   }
 
   /*
-   * @todo #54:60m/DEV Fake subscribe with ConsumerRebalanceListener is not implemented
+   * @todo #54:60m/DEV Fake subscribe with
+   *    ConsumerRebalanceListener is not implemented
    */
   @Override
   public void subscribe(final ConsumerRebalanceListener listener,

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
@@ -19,9 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-/*
- * @todo #49:45m/DEV Fake Consumer implementation
- */
 
 package io.github.eocqrs.kafka.fake;
 
@@ -43,6 +40,9 @@ import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
  */
 public final class FkConsumer<K, X> implements Consumer<K, X> {
 
+  /*
+   * @todo #54:60m/DEV Fake subscribe is not implemented
+   */
   @Override
   public void subscribe(final String... topics) {
     throw new UnsupportedOperationException("#subscribe()");
@@ -53,22 +53,34 @@ public final class FkConsumer<K, X> implements Consumer<K, X> {
     throw new UnsupportedOperationException("#subscribe()");
   }
 
+  /*
+   * @todo #54:60m/DEV Fake subscribe with ConsumerRebalanceListener is not implemented
+   */
   @Override
   public void subscribe(final ConsumerRebalanceListener listener,
                         final String... topics) {
     throw new UnsupportedOperationException("#subscribe()");
   }
 
+  /*
+   * @todo #54:60m/DEV Fake iterate is not implemented
+   */
   @Override
   public List<Dataized<X>> iterate(final String topic, final Duration timeout) {
     throw new UnsupportedOperationException("#iterate()");
   }
 
+  /*
+   * @todo #54:60m/DEV Fake unsubscribe is not implemented
+   */
   @Override
   public void unsubscribe() {
     throw new UnsupportedOperationException("#unsubscribe()");
   }
 
+  /*
+   * @todo #54:60m/DEV Fake close is not implemented
+   */
   @Override
   public void close() {
     throw new UnsupportedOperationException("#close()");

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
@@ -46,7 +46,7 @@ public final class FkProducer<K, X> implements Producer<K, X> {
   }
 
   /*
-   * @todo #44:60m/DEV Fake close is not implemented
+   * @todo #44:60m/DEV Fake producer close is not implemented
    */
   @Override
   public void close() {

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
@@ -19,9 +19,6 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-/*
- * @todo #10:45m/DEV Fake Producer implementation
- */
 
 package io.github.eocqrs.kafka.fake;
 
@@ -40,11 +37,17 @@ import org.apache.kafka.clients.producer.RecordMetadata;
  */
 public final class FkProducer<K, X> implements Producer<K, X> {
 
+  /*
+   * @todo #44:60m/DEV Fake send is not implemented
+   */
   @Override
   public Future<RecordMetadata> send(final K key, final Data<X> message) {
     throw new UnsupportedOperationException("#send()");
   }
 
+  /*
+   * @todo #44:60m/DEV Fake close is not implemented
+   */
   @Override
   public void close() {
     throw new UnsupportedOperationException("#close()");

--- a/src/test/java/io/github/eocqrs/kafka/consumer/KfConsumerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/consumer/KfConsumerTest.java
@@ -32,7 +32,9 @@ import io.github.eocqrs.kafka.parameters.KfFlexible;
 import io.github.eocqrs.kafka.parameters.KfParams;
 import io.github.eocqrs.kafka.parameters.ValueDeserializer;
 import io.github.eocqrs.kafka.xml.KfXmlFlexible;
+
 import java.util.Collection;
+
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.common.TopicPartition;
@@ -55,7 +57,7 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 final class KfConsumerTest {
 
   @Test
-  void subscribes(
+  void subscribesWithoutException(
     @Mock final ConsumerSettings<String, String> settings,
     @Mock final KafkaConsumer<String, String> consumer
   ) {
@@ -79,6 +81,18 @@ final class KfConsumerTest {
     assertDoesNotThrow(
       underTest::close
     );
+  }
+
+  @Test
+  void unsubscribesWithoutException(
+    @Mock final ConsumerSettings<String, String> settings,
+    @Mock final KafkaConsumer<String, String> origin
+  ) {
+    Mockito.when(settings.consumer()).thenReturn(origin);
+    final Consumer<String, String> consumer =
+      new KfConsumer<>(settings);
+    assertDoesNotThrow(consumer::unsubscribe);
+    assertDoesNotThrow(consumer::close);
   }
 
   @Test

--- a/src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java
@@ -78,6 +78,10 @@ final class FkConsumerTest {
     );
     assertThrows(
       UnsupportedOperationException.class,
+      consumer::unsubscribe
+    );
+    assertThrows(
+      UnsupportedOperationException.class,
       consumer::close
     );
   }


### PR DESCRIPTION
closes #288

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds an `unsubscribe` method to the `Consumer` interface and implements it in the `KfConsumer` and `FkConsumer` classes. It also adds TODOs for implementing `subscribe`, `iterate`, and `close` methods in the `FkConsumer` class.

### Detailed summary
- Adds `unsubscribe` method to `Consumer` interface
- Implements `unsubscribe` method in `KfConsumer` and `FkConsumer`
- Adds TODOs for implementing `subscribe`, `iterate`, and `close` methods in `FkConsumer`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->