### PR TITLE
DeliveryTimeoutMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,40 +229,41 @@ consumer.subscribe(new ConsumerRebalanceListener() {
 ```
 
 ## Config API
-| Kafka Property                  | eo-kafka API                                                                                                                                                    | XML tag
-|---------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------| ----------------------
-| `bootstrap.servers`             | [BootstrapServers](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/BootstrapServers.java)                       | bootstrapServers
-| `key.serializer`                | [KeySerializer](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/KeySerializer.java)                             | keySerializer
-| `value.serializer`              | [ValueSerializer](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/ValueSerializer.java)                         | valueSerializer
-| `key.deserializer`              | [KeyDeserializer](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/KeyDeserializer.java)                         | keyDeserializer
-| `value.deserializer`            | [ValueDeserializer](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/ValueDeserializer.java)                     | valueDeserializer
-| `group.id`                      | [GroupId](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/GroupId.java)                                         | groupId
-| `auto.offset.reset`             | [AutoOffsetReset](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/AutoOffsetReset.java)                         | autoOffsetReset
- | `client.id`                     | [ClientId](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/ClientId.java)                                       | clientId
-| `acks`                          | [Acks](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/Acks.java)                                               | acks
-| `security.protocol`             | [SecurityProtocol](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/SecurityProtocol.java)                       | securityProtocol
-| `sasl.jaas.config`              | [SaslJaasConfig](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/SaslJaasConfig.java)                           | saslJaasConfig
-| `sasl.mechanism`                | [SaslMechanism](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/SaslMechanism.java)                             | saslMechanism
-| `batch.size`                    | [BatchSize](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/BatchSize.java)                                     | batchSize
-| `buffer.memory`                 | [BufferMemory](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/BufferMemory.java)                               | bufferMemory
-| `linger.ms`                     | [LingerMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/LingerMs.java)                                       | lingerMs
-| `retries`                       | [Retries](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/Retries.java)                                         | retries
-| `retry.backoff.ms`              | [RetryBackoffMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/RetryBackoffMs.java)                           | retryBackoffMs
-| `compression.type`              | [CompressionType](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/CompressionType.java)                         | compressionType
-| `partition.assignment.strategy` | [PartitionAssignmentStrategy](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/PartitionAssignmentStrategy.java) | partitionAssignmentStrategy
-| `max.poll.records`              | [MaxPollRecords](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/MaxPollRecords.java)                           | maxPollRecords
-| `heartbeat.interval.ms`         | [HeartbeatIntervalMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/HeartbeatIntervalMs.java)                 | heartbeatIntervalMs
-| `enable.auto.commit`            | [EnableAutoCommit](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/EnableAutoCommit.java)                       | enableAutoCommit
-| `session.timeout.ms`            | [SessionTimeoutMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/SessionTimeoutMs.java)                       | sessionTimeoutMs
-| `max.partition.fetch.bytes`     | [MaxPartitionFetchBytes](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/MaxPartitionFetchBytes.java)           | maxPartitionFetchBytes
-| `fetch.max.wait.ms`             | [FetchMaxWaitMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/FetchMaxWaitMs.java)                           | fetchMaxWaitMs
-| `fetch.min.bytes`               | [FetchMinBytes](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/FetchMinBytes.java)                             | fetchMinBytes
-| `send.buffer.bytes`             | [SendBufferBytes](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/SendBufferBytes.java)                         | sendBufferBytes
-| `receive.buffer.bytes`          | [ReceiveBufferBytes](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/ReceiveBufferBytes.java)                   | receiveBufferBytes
-| `max.block.ms`                  | [MaxBlockMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/MaxBlockMs.java)                                   | maxBlockMs
-| `max.request.size`              | [MaxRqSize](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/MaxRqSize.java)                                     | maxRequestSize
-| `group.instance.id`             | [GroupInstanceId](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/GroupInstanceId.java)                                              | groupInstanceId
-| `max.in.flight.requests.per.connection`             | [MaxInFlightRq](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/MaxInFlightRq.java)                                              | maxInFlightRequestsPerConnection
+| Kafka Property                         | eo-kafka API                                                                                                                                                   | XML tag
+|----------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------| ----------------------
+| `bootstrap.servers`                    | [BootstrapServers](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/BootstrapServers.java)                      | bootstrapServers
+| `key.serializer`                       | [KeySerializer](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/KeySerializer.java)                            | keySerializer
+| `value.serializer`                     | [ValueSerializer](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/ValueSerializer.java)                        | valueSerializer
+| `key.deserializer`                     | [KeyDeserializer](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/KeyDeserializer.java)                        | keyDeserializer
+| `value.deserializer`                   | [ValueDeserializer](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/ValueDeserializer.java)                    | valueDeserializer
+| `group.id`                             | [GroupId](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/GroupId.java)                                        | groupId
+| `auto.offset.reset`                    | [AutoOffsetReset](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/AutoOffsetReset.java)                        | autoOffsetReset
+ | `client.id`                            | [ClientId](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/ClientId.java)                                      | clientId
+| `acks`                                 | [Acks](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/Acks.java)                                              | acks
+| `security.protocol`                    | [SecurityProtocol](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/SecurityProtocol.java)                      | securityProtocol
+| `sasl.jaas.config`                     | [SaslJaasConfig](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/SaslJaasConfig.java)                          | saslJaasConfig
+| `sasl.mechanism`                       | [SaslMechanism](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/SaslMechanism.java)                            | saslMechanism
+| `batch.size`                           | [BatchSize](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/BatchSize.java)                                    | batchSize
+| `buffer.memory`                        | [BufferMemory](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/BufferMemory.java)                              | bufferMemory
+| `linger.ms`                            | [LingerMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/LingerMs.java)                                      | lingerMs
+| `retries`                              | [Retries](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/Retries.java)                                        | retries
+| `retry.backoff.ms`                     | [RetryBackoffMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/RetryBackoffMs.java)                          | retryBackoffMs
+| `compression.type`                     | [CompressionType](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/CompressionType.java)                        | compressionType
+| `partition.assignment.strategy`        | [PartitionAssignmentStrategy](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/PartitionAssignmentStrategy.java) | partitionAssignmentStrategy
+| `max.poll.records`                     | [MaxPollRecords](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/MaxPollRecords.java)                          | maxPollRecords
+| `heartbeat.interval.ms`                | [HeartbeatIntervalMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/HeartbeatIntervalMs.java)                | heartbeatIntervalMs
+| `enable.auto.commit`                   | [EnableAutoCommit](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/EnableAutoCommit.java)                      | enableAutoCommit
+| `session.timeout.ms`                   | [SessionTimeoutMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/SessionTimeoutMs.java)                      | sessionTimeoutMs
+| `max.partition.fetch.bytes`            | [MaxPartitionFetchBytes](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/MaxPartitionFetchBytes.java)          | maxPartitionFetchBytes
+| `fetch.max.wait.ms`                    | [FetchMaxWaitMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/FetchMaxWaitMs.java)                          | fetchMaxWaitMs
+| `fetch.min.bytes`                      | [FetchMinBytes](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/FetchMinBytes.java)                            | fetchMinBytes
+| `send.buffer.bytes`                    | [SendBufferBytes](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/SendBufferBytes.java)                        | sendBufferBytes
+| `receive.buffer.bytes`                 | [ReceiveBufferBytes](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/ReceiveBufferBytes.java)                  | receiveBufferBytes
+| `max.block.ms`                         | [MaxBlockMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/MaxBlockMs.java)                                  | maxBlockMs
+| `max.request.size`                     | [MaxRqSize](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/MaxRqSize.java)                                    | maxRequestSize
+| `group.instance.id`                    | [GroupInstanceId](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/GroupInstanceId.java)                        | groupInstanceId
+| `max.in.flight.requests.per.connection` | [MaxInFlightRq](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/MaxInFlightRq.java)                            | maxInFlightRequestsPerConnection
+| `delivery.timeout.ms`                  | [DeliveryTimeoutMs](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/DeliveryTimeoutMs.java)                    | deliveryTimeoutMs
 
 ## How to Contribute
 

--- a/src/main/java/io/github/eocqrs/kafka/parameters/DeliveryTimeoutMs.java
+++ b/src/main/java/io/github/eocqrs/kafka/parameters/DeliveryTimeoutMs.java
@@ -1,0 +1,41 @@
+/*
+ *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.parameters;
+
+/**
+ * It's a wrapper for the `delivery.timeout.ms` kafka attribute.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.2.3
+ */
+public final class DeliveryTimeoutMs extends KfAttrEnvelope {
+
+  /**
+   * Ctor.
+   *
+   * @param val The value
+   */
+  public DeliveryTimeoutMs(final String val) {
+    super(val, "delivery.timeout.ms");
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/parameters/DeliveryTimeoutMsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/parameters/DeliveryTimeoutMsTest.java
@@ -1,0 +1,71 @@
+/*
+ *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.parameters;
+
+import io.github.eocqrs.kafka.ParamsAttr;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link DeliveryTimeoutMs}
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.2.3
+ */
+final class DeliveryTimeoutMsTest {
+
+  /**
+   * Under test.
+   */
+  private ParamsAttr timeout;
+
+  @BeforeEach
+  void setUp() {
+    this.timeout = new DeliveryTimeoutMs("20");
+  }
+
+  @Test
+  void writesRightName() {
+    MatcherAssert.assertThat(
+      "Name in right format",
+      this.timeout.name(),
+      Matchers.equalTo(
+        ProducerConfig.DELIVERY_TIMEOUT_MS_CONFIG
+      )
+    );
+  }
+
+  @Test
+  void writesRightXml() {
+    MatcherAssert.assertThat(
+      "XML in right format",
+      this.timeout.asXml(),
+      Matchers.equalTo(
+        "<deliveryTimeoutMs>20</deliveryTimeoutMs>"
+      )
+    );
+  }
+}


### PR DESCRIPTION
closes #312 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a new class `DeliveryTimeoutMs` and its corresponding test case to the `io.github.eocqrs.kafka.parameters` package. 

### Detailed summary
- Adds `DeliveryTimeoutMs` class to wrap the `delivery.timeout.ms` Kafka attribute
- Adds corresponding test case `DeliveryTimeoutMsTest` to test the functionality of the `DeliveryTimeoutMs` class.

> The following files were skipped due to too many changes: `README.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->