### PR TITLE
wrapping puzzle off

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/consumer/KfConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/consumer/KfConsumer.java
@@ -82,10 +82,6 @@ public final class KfConsumer<K, X> implements Consumer<K, X> {
     this.origin.subscribe(new ListOf<>(topics), listener);
   }
 
-  /**
-   * @todo #289:30m/DEV ConsumerRecords wrapping up
-   * we have to wrap the ConsumerRecords into some object
-   */
   @Override
   public ConsumerRecords<K, X> records(
     final String topic, final Duration timeout


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR removes a to-do comment and does not introduce any new changes.

### Detailed summary
- Removed a to-do comment regarding wrapping up `ConsumerRecords` into an object.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->