### PR TITLE
migration to Synchronized `xfake` 0.1.2 storage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@ SOFTWARE.
     <junit-api.version>5.9.3</junit-api.version>
     <junit-params.version>5.9.3</junit-params.version>
     <assert4j-core.version>3.24.2</assert4j-core.version>
-    <xfake.version>0.0.1</xfake.version>
+    <xfake.version>0.1.2</xfake.version>
     <xembly.version>0.28.1</xembly.version>
     <maven-surefire-plugin.version>3.1.0</maven-surefire-plugin.version>
     <maven-verifier-plugin.version>1.1</maven-verifier-plugin.version>

--- a/src/main/java/io/github/eocqrs/kafka/fake/storage/ImmutableReentrantLock.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/storage/ImmutableReentrantLock.java
@@ -30,7 +30,7 @@ import java.util.concurrent.locks.ReentrantLock;
  *
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.2.3
- * @deprecated use {@link io.github.eocqrs.xfake.ImmutableReentrantLock}
+ * @deprecated
  */
 @Deprecated(since = "0.2.4")
 final class ImmutableReentrantLock extends ReentrantLock {

--- a/src/test/java/io/github/eocqrs/kafka/fake/InXmlTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/InXmlTest.java
@@ -25,6 +25,8 @@ package io.github.eocqrs.kafka.fake;
 import io.github.eocqrs.kafka.data.KfData;
 import io.github.eocqrs.xfake.FkStorage;
 import io.github.eocqrs.xfake.InFile;
+import io.github.eocqrs.xfake.Logged;
+import io.github.eocqrs.xfake.Synchronized;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -49,7 +51,10 @@ final class InXmlTest {
 
   @BeforeEach
   void setUp() throws Exception {
-    this.storage = new InFile("fake-kafka", "<broker/>");
+    this.storage =
+      new Synchronized(
+        new InFile("fake-kafka", "<broker/>")
+      );
   }
 
   @Test


### PR DESCRIPTION
closes #348

<!-- start pr-codex -->

---

## PR-Codex overview
This PR deprecates an old class and updates dependencies. It also adds synchronization to an existing test. 

### Detailed summary
- Deprecates `ImmutableReentrantLock` class
- Updates `xfake` version to `0.1.2`
- Adds `Synchronized` wrapper to `InXmlTest` test setup method.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->