### PR TITLE
Class ctors

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/parameters/KeyDeserializer.java
+++ b/src/main/java/io/github/eocqrs/kafka/parameters/KeyDeserializer.java
@@ -33,6 +33,15 @@ public final class KeyDeserializer extends KfAttrEnvelope {
   /**
    * Ctor.
    *
+   * @param deserializer The deserializer class.
+   */
+  public KeyDeserializer(final Class<?> deserializer) {
+    this(deserializer.getCanonicalName());
+  }
+
+  /**
+   * Ctor.
+   *
    * @param value The value.
    */
   public KeyDeserializer(final String value) {

--- a/src/main/java/io/github/eocqrs/kafka/parameters/KeySerializer.java
+++ b/src/main/java/io/github/eocqrs/kafka/parameters/KeySerializer.java
@@ -33,6 +33,15 @@ public final class KeySerializer extends KfAttrEnvelope {
   /**
    * Ctor.
    *
+   * @param serializer The serializer class.
+   */
+  public KeySerializer(final Class<?> serializer) {
+    this(serializer.getCanonicalName());
+  }
+
+  /**
+   * Ctor.
+   *
    * @param value The value.
    */
   public KeySerializer(final String value) {

--- a/src/main/java/io/github/eocqrs/kafka/parameters/ValueDeserializer.java
+++ b/src/main/java/io/github/eocqrs/kafka/parameters/ValueDeserializer.java
@@ -33,6 +33,15 @@ public final class ValueDeserializer extends KfAttrEnvelope {
   /**
    * Ctor.
    *
+   * @param deserializer The deserializer class.
+   */
+  public ValueDeserializer(final Class<?> deserializer) {
+    this(deserializer.getCanonicalName());
+  }
+
+  /**
+   * Ctor.
+   *
    * @param value The value.
    */
   public ValueDeserializer(final String value) {

--- a/src/main/java/io/github/eocqrs/kafka/parameters/ValueSerializer.java
+++ b/src/main/java/io/github/eocqrs/kafka/parameters/ValueSerializer.java
@@ -33,6 +33,15 @@ public final class ValueSerializer extends KfAttrEnvelope {
   /**
    * Ctor.
    *
+   * @param serializer The serializer class.
+   */
+  public ValueSerializer(final Class<?> serializer) {
+    this(serializer.getCanonicalName());
+  }
+
+  /**
+   * Ctor.
+   *
    * @param value The value.
    */
   public ValueSerializer(final String value) {

--- a/src/test/java/io/github/eocqrs/kafka/parameters/KeyDeserializerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/parameters/KeyDeserializerTest.java
@@ -23,6 +23,7 @@
 package io.github.eocqrs.kafka.parameters;
 
 import io.github.eocqrs.kafka.ParamsAttr;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -63,4 +64,16 @@ final class KeyDeserializerTest {
       Matchers.equalTo("<keyDeserializer>kd</keyDeserializer>")
     );
   }
+
+  @Test
+  void writesRightXmlViaClass() {
+    MatcherAssert.assertThat(
+      "XML in right format",
+      new KeyDeserializer(StringDeserializer.class).asXml(),
+      Matchers.equalTo(
+        "<keyDeserializer>org.apache.kafka.common.serialization.StringDeserializer</keyDeserializer>"
+      )
+    );
+  }
+
 }

--- a/src/test/java/io/github/eocqrs/kafka/parameters/KeySerializerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/parameters/KeySerializerTest.java
@@ -23,6 +23,7 @@
 package io.github.eocqrs.kafka.parameters;
 
 import io.github.eocqrs.kafka.ParamsAttr;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,6 +62,17 @@ final class KeySerializerTest {
       "XML in right format",
       this.key.asXml(),
       Matchers.equalTo("<keySerializer>ks</keySerializer>")
+    );
+  }
+
+  @Test
+  void writesRightXmlViaClass() {
+    MatcherAssert.assertThat(
+      "XML in right format",
+      new KeySerializer(StringSerializer.class).asXml(),
+      Matchers.equalTo(
+        "<keySerializer>org.apache.kafka.common.serialization.StringSerializer</keySerializer>"
+      )
     );
   }
 }

--- a/src/test/java/io/github/eocqrs/kafka/parameters/ValueDeserializerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/parameters/ValueDeserializerTest.java
@@ -23,6 +23,7 @@
 package io.github.eocqrs.kafka.parameters;
 
 import io.github.eocqrs.kafka.ParamsAttr;
+import org.apache.kafka.common.serialization.StringDeserializer;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,6 +62,17 @@ final class ValueDeserializerTest {
       "XML in right format",
       this.key.asXml(),
       Matchers.equalTo("<valueDeserializer>vd</valueDeserializer>")
+    );
+  }
+
+  @Test
+  void writesRightXmlViaClass() {
+    MatcherAssert.assertThat(
+      "XML in right format",
+      new ValueDeserializer(StringDeserializer.class).asXml(),
+      Matchers.equalTo(
+        "<valueDeserializer>org.apache.kafka.common.serialization.StringDeserializer</valueDeserializer>"
+      )
     );
   }
 }

--- a/src/test/java/io/github/eocqrs/kafka/parameters/ValueSerializerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/parameters/ValueSerializerTest.java
@@ -23,6 +23,7 @@
 package io.github.eocqrs.kafka.parameters;
 
 import io.github.eocqrs.kafka.ParamsAttr;
+import org.apache.kafka.common.serialization.StringSerializer;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -61,6 +62,17 @@ final class ValueSerializerTest {
       "XML in right format",
       this.key.asXml(),
       Matchers.equalTo("<valueSerializer>vs</valueSerializer>")
+    );
+  }
+
+  @Test
+  void writesRightXmlViaClass() {
+    MatcherAssert.assertThat(
+      "XML in right format",
+      new ValueSerializer(StringSerializer.class).asXml(),
+      Matchers.equalTo(
+        "<valueSerializer>org.apache.kafka.common.serialization.StringSerializer</valueSerializer>"
+      )
     );
   }
 }


### PR DESCRIPTION
@h1alexbel take a look, please 

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds constructors to the `KeySerializer`, `ValueSerializer`, `KeyDeserializer`, and `ValueDeserializer` classes that accept a serializer/deserializer class. It also adds tests for these constructors.

### Detailed summary
- Added constructors that accept a serializer/deserializer class to `KeySerializer`, `ValueSerializer`, `KeyDeserializer`, and `ValueDeserializer` classes
- Updated the constructors to use `serializer.getCanonicalName()` and `deserializer.getCanonicalName()`
- Added tests for the new constructors

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->