### PR TITLE
Broker too many methods dirs classification

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/fake/DatasetDirs.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/DatasetDirs.java
@@ -7,6 +7,8 @@ import org.xembly.Directives;
 /**
  * Dataset Directives.
  *
+ * @param <K> Dataset key type
+ * @param <X> Dataset data type
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.3.5
  */

--- a/src/main/java/io/github/eocqrs/kafka/fake/DatasetDirs.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/DatasetDirs.java
@@ -1,0 +1,55 @@
+package io.github.eocqrs.kafka.fake;
+
+import io.github.eocqrs.kafka.Data;
+import org.cactoos.Scalar;
+import org.xembly.Directives;
+
+/**
+ * Dataset Directives.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+public final class DatasetDirs<K, X> implements Scalar<Directives> {
+
+  /**
+   * Dataset Key.
+   */
+  private final K key;
+  /**
+   * Dataset Data.
+   */
+  private final Data<X> data;
+
+  /**
+   * Ctor.
+   *
+   * @param key  Key
+   * @param data Data
+   */
+  public DatasetDirs(final K key, final Data<X> data) {
+    this.key = key;
+    this.data = data;
+  }
+
+  @Override
+  public Directives value() throws Exception {
+    return new Directives()
+      .xpath(
+        "broker/topics/topic[name = '%s']"
+          .formatted(
+            this.data.topic()
+          )
+      )
+      .addIf("datasets")
+      .add("dataset")
+      .add("partition")
+      .set(this.data.partition())
+      .up()
+      .addIf("key")
+      .set(this.key)
+      .up()
+      .addIf("value")
+      .set(this.data.dataized().dataize());
+  }
+}

--- a/src/main/java/io/github/eocqrs/kafka/fake/InXml.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/InXml.java
@@ -22,9 +22,7 @@
 
 package io.github.eocqrs.kafka.fake;
 
-import io.github.eocqrs.kafka.Data;
 import io.github.eocqrs.xfake.FkStorage;
-import org.cactoos.list.ListOf;
 import org.xembly.Directives;
 
 import java.util.Collection;
@@ -59,55 +57,8 @@ public final class InXml implements FkBroker {
   }
 
   @Override
-  public <X> FkBroker withDataset(
-    final Object key,
-    final Data<X> data
-  ) throws Exception {
-    this.storage.apply(
-      new Directives()
-        .xpath(
-          "broker/topics/topic[name = '%s']"
-            .formatted(
-              data.topic()
-            )
-        )
-        .addIf("datasets")
-        .add("dataset")
-        .add("partition")
-        .set(data.partition())
-        .up()
-        .addIf("key")
-        .set(key)
-        .up()
-        .addIf("value")
-        .set(data.dataized().dataize())
-    );
-    return this;
-  }
-
-  @Override
-  public FkBroker withTopics(final String... topics) {
-    new ListOf<>(topics)
-      .forEach(
-        topic -> {
-          try {
-            this.storage.apply(
-              new Directives()
-                .xpath("broker/topics")
-                .add("topic")
-                .addIf("name")
-                .set(topic)
-                .up()
-                .addIf("datasets")
-            );
-          } catch (final Exception ex) {
-            throw new IllegalStateException(
-              "Topics can't be applied",
-              ex
-            );
-          }
-        }
-      );
+  public FkBroker with(final Directives dirs) throws Exception {
+    this.storage.apply(dirs);
     return this;
   }
 

--- a/src/main/java/io/github/eocqrs/kafka/fake/TopicDirs.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/TopicDirs.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,33 +22,40 @@
 
 package io.github.eocqrs.kafka.fake;
 
+import org.cactoos.Scalar;
 import org.xembly.Directives;
 
-import java.util.Collection;
-
 /**
- * Fake Kafka Broker.
+ * Topic Directives.
  *
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.2.3
+ * @see Directives
+ * @since 0.3.5
  */
-public interface FkBroker {
+public final class TopicDirs implements Scalar<Directives> {
 
   /**
-   * With new Directives.
-   *
-   * @param dirs Directives
-   * @return FkBroker
-   * @throws Exception When something went wrong.
+   * Topic.
    */
-  FkBroker with(Directives dirs) throws Exception;
+  private final String topic;
 
   /**
-   * Query data.
+   * Ctor.
    *
-   * @param query Query
-   * @return Collection of Strings
-   * @throws Exception When something went wrong.
+   * @param tpc Topic
    */
-  Collection<String> data(String query) throws Exception;
+  public TopicDirs(final String tpc) {
+    this.topic = tpc;
+  }
+
+  @Override
+  public Directives value() throws Exception {
+    return new Directives()
+      .xpath("broker/topics")
+      .add("topic")
+      .addIf("name")
+      .set(this.topic)
+      .up()
+      .addIf("datasets");
+  }
 }

--- a/src/test/java/io/github/eocqrs/kafka/fake/DatasetDirsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/DatasetDirsTest.java
@@ -15,6 +15,8 @@ final class DatasetDirsTest {
 
   @Test
   void dirsInRightFormat() throws Exception {
+    final String directives = "XPATH \"broker/topics/topic[name = &apos;&apos;]\";ADDIF \"datasets\";ADD \"dataset\";ADD \"partition\";\n" +
+      "4:SET \"0\";UP;ADDIF \"key\";SET \"test\";UP;ADDIF \"value\";SET \"\";";
     MatcherAssert.assertThat(
       "Directives in the right format",
       new DatasetDirs<>(
@@ -22,8 +24,7 @@ final class DatasetDirsTest {
         new KfData<>("", "", 0)
       ).value().toString(),
       Matchers.equalTo(
-        "XPATH \"broker/topics/topic[name = &apos;&apos;]\";ADDIF \"datasets\";ADD \"dataset\";ADD \"partition\";\n" +
-          "4:SET \"0\";UP;ADDIF \"key\";SET \"test\";UP;ADDIF \"value\";SET \"\";"
+        directives
       )
     );
   }

--- a/src/test/java/io/github/eocqrs/kafka/fake/DatasetDirsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/DatasetDirsTest.java
@@ -1,0 +1,30 @@
+package io.github.eocqrs.kafka.fake;
+
+import io.github.eocqrs.kafka.data.KfData;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link DatasetDirs}.
+ *
+ * @author Aliaksei Bialiauski (abialaiuski.dev@gmail.com)
+ * @since 0.3.5
+ */
+final class DatasetDirsTest {
+
+  @Test
+  void dirsInRightFormat() throws Exception {
+    MatcherAssert.assertThat(
+      "Directives in the right format",
+      new DatasetDirs<>(
+        "test",
+        new KfData<>("", "", 0)
+      ).value().toString(),
+      Matchers.equalTo(
+        "XPATH \"broker/topics/topic[name = &apos;&apos;]\";ADDIF \"datasets\";ADD \"dataset\";ADD \"partition\";\n" +
+          "4:SET \"0\";UP;ADDIF \"key\";SET \"test\";UP;ADDIF \"value\";SET \"\";"
+      )
+    );
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/fake/InXmlTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/InXmlTest.java
@@ -25,7 +25,6 @@ package io.github.eocqrs.kafka.fake;
 import io.github.eocqrs.kafka.data.KfData;
 import io.github.eocqrs.xfake.FkStorage;
 import io.github.eocqrs.xfake.InFile;
-import io.github.eocqrs.xfake.Logged;
 import io.github.eocqrs.xfake.Synchronized;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -85,7 +84,7 @@ final class InXmlTest {
   @Test
   void createsTopic() throws Exception {
     new InXml(this.storage)
-      .withTopics("test-1");
+      .with(new TopicDirs("test-1").value());
     MatcherAssert.assertThat(
       "Topic is present in XML",
       this.storage.xml()
@@ -97,8 +96,10 @@ final class InXmlTest {
 
   @Test
   void createsMultipleTopics() throws Exception {
-    new InXml(this.storage)
-      .withTopics("test-1", "test-2", "test-3");
+    new InXml(storage)
+      .with(new TopicDirs("test-1").value())
+      .with(new TopicDirs("test-2").value())
+      .with(new TopicDirs("test-3").value());
     MatcherAssert.assertThat(
       "Topic is present in XML",
       this.storage.xml()
@@ -127,14 +128,16 @@ final class InXmlTest {
     final String topic = "test-1";
     final String value = "value";
     new InXml(this.storage)
-      .withTopics(topic)
-      .withDataset(
-        "test",
-        new KfData<>(
-          value,
-          topic,
-          0
-        )
+      .with(new TopicDirs(topic).value())
+      .with(
+        new DatasetDirs<>(
+          "test",
+          new KfData<>(
+            value,
+            topic,
+            0
+          )
+        ).value()
       );
     MatcherAssert.assertThat(
       "Dataset is present",
@@ -166,7 +169,7 @@ final class InXmlTest {
     final String topic = "temp";
     final FkBroker broker = new InXml(
       this.storage
-    ).withTopics(topic);
+    ).with(new TopicDirs(topic).value());
     MatcherAssert.assertThat(
       "Broker queries data and gets right response",
       broker.data(

--- a/src/test/java/io/github/eocqrs/kafka/fake/TopicDirsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/TopicDirsTest.java
@@ -1,0 +1,27 @@
+package io.github.eocqrs.kafka.fake;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link TopicDirs}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+final class TopicDirsTest {
+
+  @Test
+  void dirsInRightFormat() throws Exception {
+    MatcherAssert.assertThat(
+      "Directives in the right format",
+      new TopicDirs("test")
+        .value()
+        .toString(),
+      Matchers.equalTo(
+        "XPATH \"broker/topics\";ADD \"topic\";ADDIF \"name\";SET \"test\";UP;ADDIF \"datasets\";"
+      )
+    );
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/fake/TopicDirsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/TopicDirsTest.java
@@ -14,13 +14,14 @@ final class TopicDirsTest {
 
   @Test
   void dirsInRightFormat() throws Exception {
+    final String directives = "XPATH \"broker/topics\";ADD \"topic\";ADDIF \"name\";SET \"test\";UP;ADDIF \"datasets\";";
     MatcherAssert.assertThat(
       "Directives in the right format",
       new TopicDirs("test")
         .value()
         .toString(),
       Matchers.equalTo(
-        "XPATH \"broker/topics\";ADD \"topic\";ADDIF \"name\";SET \"test\";UP;ADDIF \"datasets\";"
+        directives
       )
     );
   }


### PR DESCRIPTION
closes #364

@l3r8yJ take a look, please

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds new test cases and refactors the `FkBroker` interface and related classes in the `io.github.eocqrs.kafka.fake` package. It also adds new `TopicDirs` and `DatasetDirs` classes for building XML directives for topics and datasets.

### Detailed summary
- Adds `TopicDirs` and `DatasetDirs` classes for building XML directives for topics and datasets.
- Refactors the `FkBroker` interface and related classes.
- Adds new test cases for the `TopicDirs`, `DatasetDirs`, and `InXml` classes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->