### PR TITLE
fake consumer close, producer close with id

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
@@ -22,12 +22,16 @@
 
 package io.github.eocqrs.kafka.fake;
 
+import com.jcabi.log.Logger;
 import io.github.eocqrs.kafka.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
 
+import java.time.Clock;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.Collection;
+import java.util.UUID;
 
 /**
  * Fake Consumer.
@@ -39,9 +43,26 @@ import java.util.Collection;
  */
 public final class FkConsumer<K, X> implements Consumer<K, X> {
 
-  /*
-   * @todo #54:60m/DEV Fake subscribe is not implemented
+  /**
+   * Client id.
    */
+  private final UUID id;
+  /**
+   * Broker.
+   */
+  private final FkBroker broker;
+
+  /**
+   * Ctor.
+   *
+   * @param identifier UUID id
+   * @param brkr       FkBroker
+   */
+  public FkConsumer(final UUID identifier, final FkBroker brkr) {
+    this.id = identifier;
+    this.broker = brkr;
+  }
+
   @Override
   public void subscribe(final String... topics) {
     throw new UnsupportedOperationException("#subscribe()");
@@ -80,11 +101,16 @@ public final class FkConsumer<K, X> implements Consumer<K, X> {
     throw new UnsupportedOperationException("#unsubscribe()");
   }
 
-  /*
-   * @todo #54:60m/DEV Fake consumer close is not implemented
-   */
   @Override
   public void close() {
-    throw new UnsupportedOperationException("#close()");
+    Logger.info(
+      this, "Consumer %s closed at %s"
+        .formatted(
+          this.id,
+          LocalDateTime.now(
+            Clock.systemUTC()
+          )
+        )
+    );
   }
 }

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
@@ -63,6 +63,9 @@ public final class FkConsumer<K, X> implements Consumer<K, X> {
     this.broker = brkr;
   }
 
+  /*
+   * @todo #54:60m/DEV Fake subscribe is not implemented
+   */
   @Override
   public void subscribe(final String... topics) {
     throw new UnsupportedOperationException("#subscribe()");

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
@@ -30,6 +30,7 @@ import org.apache.kafka.common.TopicPartition;
 
 import java.time.Clock;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import java.util.concurrent.Future;
 
 /**
@@ -55,6 +56,10 @@ public final class FkProducer<K, X> implements Producer<K, X> {
    */
   private static final long TIMESTAMP = 0L;
   /**
+   * Client id.
+   */
+  private final UUID id;
+  /**
    * Broker.
    */
   private final FkBroker broker;
@@ -62,9 +67,11 @@ public final class FkProducer<K, X> implements Producer<K, X> {
   /**
    * Ctor.
    *
-   * @param brkr Broker
+   * @param client Client UUID id
+   * @param brkr   Broker
    */
-  public FkProducer(final FkBroker brkr) {
+  public FkProducer(final UUID client, final FkBroker brkr) {
+    this.id = client;
     this.broker = brkr;
   }
 
@@ -112,8 +119,9 @@ public final class FkProducer<K, X> implements Producer<K, X> {
   @Override
   public void close() {
     Logger.info(
-      this, "Producer closed at %s"
+      this, "Producer %s closed at %s"
         .formatted(
+          this.id,
           LocalDateTime.now(
             Clock.systemUTC()
           )

--- a/src/test/java/io/github/eocqrs/kafka/fake/FkProducerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/FkProducerTest.java
@@ -40,6 +40,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.io.IOException;
+import java.util.UUID;
 import java.util.concurrent.Future;
 import java.util.logging.Level;
 
@@ -72,7 +73,7 @@ final class FkProducerTest {
   void createsFakeProducerWithMockBroker(@Mock final FkBroker mock)
     throws IOException {
     final Producer<String, String> producer =
-      new FkProducer<>(mock);
+      new FkProducer<>(UUID.randomUUID(), mock);
     MatcherAssert.assertThat(
       "Fake producer creates with mock broker",
       producer,
@@ -84,7 +85,7 @@ final class FkProducerTest {
   @Test
   void createsFakeProducer() throws IOException {
     final Producer<String, String> producer =
-      new FkProducer<>(this.broker);
+      new FkProducer<>(UUID.randomUUID(), this.broker);
     MatcherAssert.assertThat(
       "Fake producer creates",
       producer,
@@ -96,7 +97,7 @@ final class FkProducerTest {
   @Test
   void closesWithoutException() {
     final Producer<String, String> producer =
-      new FkProducer<>(this.broker);
+      new FkProducer<>(UUID.randomUUID(), this.broker);
     Assertions.assertDoesNotThrow(producer::close);
   }
 
@@ -112,7 +113,7 @@ final class FkProducerTest {
   @Test
   void sendsMessageWithoutTopicExistence() throws Exception {
     final Producer<String, String> producer =
-      new FkProducer<>(this.broker);
+      new FkProducer<>(UUID.randomUUID(), this.broker);
     Assertions.assertThrows(
       IllegalArgumentException.class,
       () ->
@@ -130,6 +131,7 @@ final class FkProducerTest {
       .with(new TopicDirs(topic).value());
     final Producer<String, String> producer =
       new FkProducer<>(
+        UUID.randomUUID(),
         after
       );
     producer.send("test-key", new KfData<>(data, topic, partition));
@@ -153,6 +155,7 @@ final class FkProducerTest {
     final int partition = 0;
     final Producer<String, String> producer =
       new FkProducer<>(
+        UUID.randomUUID(),
         this.broker
           .with(new TopicDirs(topic).value())
       );


### PR DESCRIPTION
closes #298

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds a `UUID id` to `FkProducer` and `FkConsumer`, and logs the client id when closing them. It also adds tests for the new functionality.

### Detailed summary
- Adds a `UUID id` to `FkProducer` and `FkConsumer`
- Logs the client id when closing them
- Adds tests for the new functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->