### PR TITLE
Fake consumer subscribe

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
@@ -26,6 +26,7 @@ import com.jcabi.log.Logger;
 import io.github.eocqrs.kafka.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.cactoos.list.ListOf;
 
 import java.time.Clock;
 import java.time.Duration;
@@ -44,7 +45,7 @@ import java.util.UUID;
 public final class FkConsumer<K, X> implements Consumer<K, X> {
 
   /**
-   * Client id.
+   * Consumer id.
    */
   private final UUID id;
   /**
@@ -63,17 +64,22 @@ public final class FkConsumer<K, X> implements Consumer<K, X> {
     this.broker = brkr;
   }
 
-  /*
-   * @todo #54:60m/DEV Fake subscribe is not implemented
-   */
   @Override
   public void subscribe(final String... topics) {
-    throw new UnsupportedOperationException("#subscribe()");
+    this.subscribe(new ListOf<>(topics));
   }
 
   @Override
   public void subscribe(final Collection<String> topics) {
-    throw new UnsupportedOperationException("#subscribe()");
+    topics.forEach(
+      t -> {
+        try {
+          this.broker.with(new SubscribeDirs(t, this.id).value());
+        } catch (final Exception ex) {
+          throw new IllegalStateException(ex);
+        }
+      }
+    );
   }
 
   /*

--- a/src/main/java/io/github/eocqrs/kafka/fake/InXml.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/InXml.java
@@ -54,6 +54,11 @@ public final class InXml implements FkBroker {
         .xpath("broker")
         .addIf("topics")
     );
+    this.storage.apply(
+      new Directives()
+        .xpath("broker")
+        .addIf("subs")
+    );
   }
 
   @Override

--- a/src/main/java/io/github/eocqrs/kafka/fake/SubscribeDirs.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/SubscribeDirs.java
@@ -1,0 +1,69 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.fake;
+
+import org.cactoos.Scalar;
+import org.xembly.Directives;
+
+import java.util.UUID;
+
+/**
+ * Subscription Directives.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+public final class SubscribeDirs implements Scalar<Directives> {
+
+  /**
+   * Topic to subscribe.
+   */
+  private final String topic;
+  /**
+   * Consumer ID.
+   */
+  private final UUID id;
+
+  /**
+   * Ctor.
+   *
+   * @param tpc      Topic to subscribe
+   * @param consumer Consumer ID
+   */
+  public SubscribeDirs(final String tpc, final UUID consumer) {
+    this.topic = tpc;
+    this.id = consumer;
+  }
+
+  @Override
+  public Directives value() throws Exception {
+    return new Directives()
+      .xpath("broker/subs")
+      .add("sub")
+      .addIf("topic")
+      .set(this.topic)
+      .up()
+      .addIf("consumer")
+      .set(this.id);
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java
@@ -154,6 +154,19 @@ final class FkConsumerTest {
   }
 
   @Test
+  void throwsIfNull() {
+    final Consumer<String, String> consumer =
+      new FkConsumer<>(
+        UUID.randomUUID(),
+        this.broker
+      );
+    Assertions.assertThrows(
+      IllegalStateException.class,
+      () -> consumer.subscribe((String) null)
+    );
+  }
+
+  @Test
   void createsFakeConsumer() {
     final FkConsumer<String, String> consumer =
       new FkConsumer<>(UUID.randomUUID(), this.broker);

--- a/src/test/java/io/github/eocqrs/kafka/fake/InXmlTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/InXmlTest.java
@@ -82,6 +82,21 @@ final class InXmlTest {
   }
 
   @Test
+  void createsBrokerWithSubscriptions() throws Exception {
+    final FkBroker broker =
+      new InXml(
+        this.storage
+      );
+    MatcherAssert.assertThat(
+      "<subs> node is present",
+      this.storage.xml()
+        .nodes("broker/subs")
+        .isEmpty(),
+      Matchers.equalTo(false)
+    );
+  }
+
+  @Test
   void createsTopic() throws Exception {
     new InXml(this.storage)
       .with(new TopicDirs("test-1").value());

--- a/src/test/java/io/github/eocqrs/kafka/fake/SubscribeDirsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/SubscribeDirsTest.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.fake;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+/**
+ * Test case for {@link SubscribeDirs}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+final class SubscribeDirsTest {
+
+  @Test
+  void dirsInRightFormat() throws Exception {
+    final UUID uuid = UUID.fromString("a0802390-9437-4b02-9473-a726629a5472");
+    final String directives = "XPATH \"broker/subs\";ADD \"sub\";ADDIF \"topic\";SET \"test\";UP;ADDIF \"consumer\";SET \"a0802390-9437-4b02-9473-a726629a5472\";";
+    MatcherAssert.assertThat(
+      "Directives in the right format",
+      new SubscribeDirs("test", uuid)
+        .value()
+        .toString(),
+      Matchers.equalTo(
+        directives
+      )
+    );
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/fake/storage/InFileTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/storage/InFileTest.java
@@ -20,10 +20,8 @@
  * SOFTWARE.
  */
 
-package io.github.eocqrs.kafka.fake;
+package io.github.eocqrs.kafka.fake.storage;
 
-import io.github.eocqrs.kafka.fake.storage.FkStorage;
-import io.github.eocqrs.kafka.fake.storage.InFile;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Assertions;


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR adds subscription functionality to the `FkConsumer` class in the `io.github.eocqrs.kafka.fake` package. 

### Detailed summary
- Added `subscribe` method to `FkConsumer` that accepts a `String` or a `Collection<String>` of topics to subscribe to
- Created `SubscribeDirs` class to generate subscription directives
- Added tests for `FkConsumer` subscription functionality

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->