### PR TITLE
topic exists refactoring

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
@@ -80,13 +80,8 @@ public final class FkProducer<K, X> implements Producer<K, X> {
     final K key,
     final Data<X> message
   ) throws Exception {
-    final boolean exists = this.broker.data(
-        "broker/topics/topic[name = '%s']/name/text()"
-          .formatted(message.topic())
-      ).stream()
-      .anyMatch(s ->
-        s.equals(message.topic())
-      );
+    final Boolean exists =
+      new TopicExists(message.topic(), this.broker).value();
     if (!exists) {
       throw new IllegalArgumentException(
         "topic %s does not exits!"

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
@@ -80,16 +80,13 @@ public final class FkProducer<K, X> implements Producer<K, X> {
     final K key,
     final Data<X> message
   ) throws Exception {
-    final Boolean exists =
-      new TopicExists(message.topic(), this.broker).value();
-    if (!exists) {
-      throw new IllegalArgumentException(
-        "topic %s does not exits!"
-          .formatted(
-            message.topic()
-          )
-      );
-    }
+    new ThrowsOnFalse(
+      new TopicExists(message.topic(), this.broker),
+      "topic %s does not exists!"
+        .formatted(
+          message.topic()
+        )
+    ).value();
     this.broker.with(new DatasetDirs<>(key, message).value());
     final RecordMetadata metadata = new RecordMetadata(
       new TopicPartition(

--- a/src/main/java/io/github/eocqrs/kafka/fake/ThrowsOnFalse.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/ThrowsOnFalse.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.fake;
+
+import org.cactoos.Scalar;
+
+/**
+ * Throwing exception on a False logical statement.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+public final class ThrowsOnFalse implements Scalar<Boolean> {
+
+  /**
+   * Logical statement.
+   */
+  private final Scalar<Boolean> scalar;
+  /**
+   * Error message.
+   */
+  private final String message;
+
+  /**
+   * Ctor.
+   *
+   * @param sclr Boolean scalar
+   * @param msg  Error Message
+   */
+  public ThrowsOnFalse(final Scalar<Boolean> sclr, final String msg) {
+    this.scalar = sclr;
+    this.message = msg;
+  }
+
+  @Override
+  public Boolean value() throws Exception {
+    if (!this.scalar.value()) {
+      throw new IllegalArgumentException(
+        this.message
+      );
+    }
+    return true;
+  }
+}

--- a/src/main/java/io/github/eocqrs/kafka/fake/TopicExists.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/TopicExists.java
@@ -22,29 +22,44 @@
 
 package io.github.eocqrs.kafka.fake;
 
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
+import org.cactoos.Scalar;
 
 /**
- * Test case for {@link TopicDirs}.
+ * Topic Exists or not.
  *
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.3.5
  */
-final class TopicDirsTest {
+public final class TopicExists implements Scalar<Boolean> {
 
-  @Test
-  void dirsInRightFormat() throws Exception {
-    final String directives = "XPATH \"broker/topics\";ADD \"topic\";ADDIF \"name\";SET \"test\";UP;ADDIF \"datasets\";";
-    MatcherAssert.assertThat(
-      "Directives in the right format",
-      new TopicDirs("test")
-        .value()
-        .toString(),
-      Matchers.equalTo(
-        directives
-      )
-    );
+  /**
+   * Topic to check.
+   */
+  private final String topic;
+  /**
+   * Broker.
+   */
+  private final FkBroker broker;
+
+  /**
+   * Ctor.
+   *
+   * @param tpc  Topic to check
+   * @param brkr Broker
+   */
+  public TopicExists(final String tpc, final FkBroker brkr) {
+    this.topic = tpc;
+    this.broker = brkr;
+  }
+
+  @Override
+  public Boolean value() throws Exception {
+    return this.broker.data(
+        "broker/topics/topic[name = '%s']/name/text()"
+          .formatted(this.topic)
+      ).stream()
+      .anyMatch(s ->
+        s.equals(this.topic)
+      );
   }
 }

--- a/src/test/java/io/github/eocqrs/kafka/fake/ThrowsOnFalseTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/ThrowsOnFalseTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.fake;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link ThrowsOnFalse}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+final class ThrowsOnFalseTest {
+
+  @Test
+  void throwsOnFalse() {
+    final String msg = "test message";
+    final String message = Assertions.assertThrows(IllegalArgumentException.class,
+      () -> new ThrowsOnFalse(
+        () -> false, msg
+      ).value()
+    ).getMessage();
+    MatcherAssert.assertThat(
+      "Exception message in right format",
+      message,
+      Matchers.equalTo(msg)
+    );
+  }
+
+  @Test
+  void returnsTrueOnTrue() throws Exception {
+    MatcherAssert.assertThat(
+      "Returns true on true statement",
+      new ThrowsOnFalse(() -> true, "test").value(),
+      Matchers.equalTo(true)
+    );
+  }
+
+  @Test
+  void doesNotThrowOnTrue() {
+    Assertions.assertDoesNotThrow(
+      () -> new ThrowsOnFalse(
+        () -> true, "msg"
+      ).value()
+    );
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/fake/TopicExistsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/TopicExistsTest.java
@@ -22,29 +22,50 @@
 
 package io.github.eocqrs.kafka.fake;
 
+import io.github.eocqrs.xfake.InFile;
+import io.github.eocqrs.xfake.Synchronized;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Test case for {@link TopicDirs}.
+ * Test case for {@link TopicExists}.
  *
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.3.5
  */
-final class TopicDirsTest {
+final class TopicExistsTest {
+
+  private FkBroker broker;
+
+  @BeforeEach
+  void setUp() throws Exception {
+    this.broker = new InXml(
+      new Synchronized(
+        new InFile(
+          "topic-exists-test",
+          "<broker/>"
+        )
+      )
+    ).with(new TopicDirs("1.test").value());
+  }
 
   @Test
-  void dirsInRightFormat() throws Exception {
-    final String directives = "XPATH \"broker/topics\";ADD \"topic\";ADDIF \"name\";SET \"test\";UP;ADDIF \"datasets\";";
+  void returnsTrueOnExistingTopic() throws Exception {
     MatcherAssert.assertThat(
-      "Directives in the right format",
-      new TopicDirs("test")
-        .value()
-        .toString(),
-      Matchers.equalTo(
-        directives
-      )
+      "Topic is present",
+      new TopicExists("1.test", this.broker).value(),
+      Matchers.equalTo(true)
+    );
+  }
+
+  @Test
+  void returnsFalseOnUnknownTopic() throws Exception {
+    MatcherAssert.assertThat(
+      "Topic is not present",
+      new TopicExists("unknown.test", this.broker).value(),
+      Matchers.equalTo(false)
     );
   }
 }


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR introduces new classes to handle topic existence in Kafka producer. It replaces a boolean statement with a more readable and reusable code. 

### Detailed summary
- New `TopicExists` class added to check if a topic exists in Kafka broker
- New `ThrowsOnFalse` class added to throw an exception if a logical statement is false
- Existing code in `FkProducer` modified to use the new classes for topic existence checking.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->