### PR TITLE
fake consumer subscribes with consumer rebalance listener

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
@@ -82,14 +82,21 @@ public final class FkConsumer<K, X> implements Consumer<K, X> {
     );
   }
 
-  /*
-   * @todo #54:60m/DEV Fake subscribe with
-   *    ConsumerRebalanceListener is not implemented
-   */
   @Override
   public void subscribe(final ConsumerRebalanceListener listener,
                         final String... topics) {
-    throw new UnsupportedOperationException("#subscribe()");
+    new ListOf<>(topics)
+      .forEach(t -> {
+        try {
+          this.broker.with(
+            new WithRebalanceListener(
+              new SubscribeDirs(t, this.id),
+              listener
+            ).value());
+        } catch (final Exception ex) {
+          throw new IllegalStateException(ex);
+        }
+      });
   }
 
   /*

--- a/src/main/java/io/github/eocqrs/kafka/fake/WithRebalanceListener.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/WithRebalanceListener.java
@@ -1,0 +1,71 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.fake;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.cactoos.Scalar;
+import org.xembly.Directives;
+
+/**
+ * Directives with Rebalance Listener.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @see org.apache.kafka.clients.consumer.ConsumerRebalanceListener
+ * @since 0.3.5
+ */
+public final class WithRebalanceListener implements Scalar<Directives> {
+
+  /**
+   * Origin Directives.
+   */
+  private final Scalar<Directives> dirs;
+  /**
+   * ConsumerRebalanceListener.
+   */
+  private final ConsumerRebalanceListener listener;
+
+  /**
+   * Ctor.
+   *
+   * @param drs   Directives
+   * @param lstnr Listener
+   */
+  public WithRebalanceListener(
+    final Scalar<Directives> drs,
+    final ConsumerRebalanceListener lstnr
+  ) {
+    this.dirs = drs;
+    this.listener = lstnr;
+  }
+
+  @Override
+  public Directives value() throws Exception {
+    return this.dirs
+      .value()
+      .up()
+      .addIf("listener")
+      .set(this.listener.toString());
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/fake/DatasetDirsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/DatasetDirsTest.java
@@ -15,8 +15,9 @@ final class DatasetDirsTest {
 
   @Test
   void dirsInRightFormat() throws Exception {
-    final String directives = "XPATH \"broker/topics/topic[name = &apos;&apos;]\";ADDIF \"datasets\";ADD \"dataset\";ADD \"partition\";\n" +
-      "4:SET \"0\";UP;ADDIF \"key\";SET \"test\";UP;ADDIF \"value\";SET \"\";";
+    final String directives = "XPATH \"broker/topics/topic[name = &apos;&apos;]\";ADDIF "
+      + "\"datasets\";ADD \"dataset\";ADD \"partition\";\n"
+      + "4:SET \"0\";UP;ADDIF \"key\";SET \"test\";UP;ADDIF \"value\";SET \"\";";
     MatcherAssert.assertThat(
       "Directives in the right format",
       new DatasetDirs<>(

--- a/src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java
@@ -221,6 +221,27 @@ final class FkConsumerTest {
   }
 
   @Test
+  void throwsIfNullWithListener() {
+    final Consumer<String, String> consumer =
+      new FkConsumer<>(
+        UUID.randomUUID(),
+        this.broker
+      );
+    Assertions.assertThrows(
+      IllegalStateException.class,
+      () -> consumer.subscribe(new ConsumerRebalanceListener() {
+        @Override
+        public void onPartitionsRevoked(final Collection<TopicPartition> collection) {
+        }
+
+        @Override
+        public void onPartitionsAssigned(final Collection<TopicPartition> collection) {
+        }
+      }, (String) null)
+    );
+  }
+
+  @Test
   void createsFakeConsumer() {
     final FkConsumer<String, String> consumer =
       new FkConsumer<>(UUID.randomUUID(), this.broker);

--- a/src/test/java/io/github/eocqrs/kafka/fake/SubscribeDirsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/SubscribeDirsTest.java
@@ -39,7 +39,8 @@ final class SubscribeDirsTest {
   @Test
   void dirsInRightFormat() throws Exception {
     final UUID uuid = UUID.fromString("a0802390-9437-4b02-9473-a726629a5472");
-    final String directives = "XPATH \"broker/subs\";ADD \"sub\";ADDIF \"topic\";SET \"test\";UP;ADDIF \"consumer\";SET \"a0802390-9437-4b02-9473-a726629a5472\";";
+    final String directives = "XPATH \"broker/subs\";ADD \"sub\";ADDIF \"topic\";SET "
+      + "\"test\";UP;ADDIF \"consumer\";SET \"a0802390-9437-4b02-9473-a726629a5472\";";
     MatcherAssert.assertThat(
       "Directives in the right format",
       new SubscribeDirs("test", uuid)

--- a/src/test/java/io/github/eocqrs/kafka/fake/TopicDirsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/TopicDirsTest.java
@@ -36,7 +36,8 @@ final class TopicDirsTest {
 
   @Test
   void dirsInRightFormat() throws Exception {
-    final String directives = "XPATH \"broker/topics\";ADD \"topic\";ADDIF \"name\";SET \"test\";UP;ADDIF \"datasets\";";
+    final String directives = "XPATH \"broker/topics\";ADD \"topic\";ADDIF "
+      + "\"name\";SET \"test\";UP;ADDIF \"datasets\";";
     MatcherAssert.assertThat(
       "Directives in the right format",
       new TopicDirs("test")

--- a/src/test/java/io/github/eocqrs/kafka/fake/WithRebalanceListenerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/WithRebalanceListenerTest.java
@@ -1,0 +1,76 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.fake;
+
+import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
+import org.apache.kafka.common.TopicPartition;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.UUID;
+
+/**
+ * Test case for {@link WithRebalanceListener}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+final class WithRebalanceListenerTest {
+
+  @Test
+  void dirsInRightFormat() throws Exception {
+    final UUID id = UUID.fromString("a6d0094c-d393-4d63-bc4c-20b33b38bc8f");
+    final String rebalance = "rebalance";
+    final String directives =
+      "XPATH \"broker/subs\";ADD \"sub\";ADDIF \"topic\";SET \"test\";UP;ADDIF "
+        + "\"consumer\";SET \"a6d0094c-d393-4d63-bc4c-20b33b38bc8f\";"
+        + "\n7:UP;ADDIF \"listener\";SET \"rebalance\";";
+    MatcherAssert.assertThat(
+      "Directives in the right format",
+      new WithRebalanceListener(new SubscribeDirs("test", id),
+        new ConsumerRebalanceListener() {
+          @Override
+          public void onPartitionsRevoked(final Collection<TopicPartition> collection) {
+          }
+
+          @Override
+          public void onPartitionsAssigned(final Collection<TopicPartition> collection) {
+          }
+
+          @Override
+          public String toString() {
+            return rebalance;
+          }
+        })
+        .value()
+        .toString(),
+      Matchers.equalTo(
+        directives
+      )
+    );
+  }
+}


### PR DESCRIPTION
closes #295

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for ConsumerRebalanceListener to FkConsumer.

### Detailed summary
- Adds `WithRebalanceListener` class to support `ConsumerRebalanceListener`.
- Adds `subscribe` method overload that accepts `ConsumerRebalanceListener`.
- Adds tests for `WithRebalanceListener` and `FkConsumer` with `ConsumerRebalanceListener`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->