### PR TITLE
fake consumer unsubscribes

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkConsumer.java
@@ -109,12 +109,18 @@ public final class FkConsumer<K, X> implements Consumer<K, X> {
     throw new UnsupportedOperationException("#records()");
   }
 
-  /*
-   * @todo #54:60m/DEV Fake unsubscribe is not implemented
-   */
   @Override
-  public void unsubscribe() {
-    throw new UnsupportedOperationException("#unsubscribe()");
+  public void unsubscribe() throws Exception {
+    while (
+      !this.broker.data(
+        "broker/subs/sub[consumer = '%s']/consumer/text()"
+          .formatted(
+            this.id
+          )
+      ).isEmpty()
+    ) {
+      this.broker.with(new UnsubscribeDirs(this.id).value());
+    }
   }
 
   @Override

--- a/src/main/java/io/github/eocqrs/kafka/fake/UnsubscribeDirs.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/UnsubscribeDirs.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,60 +20,44 @@
  * SOFTWARE.
  */
 
-package io.github.eocqrs.kafka;
+package io.github.eocqrs.kafka.fake;
 
-import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.cactoos.Scalar;
+import org.xembly.Directives;
 
-import java.io.Closeable;
-import java.time.Duration;
-import java.util.Collection;
+import java.util.UUID;
 
 /**
- * Consumer.
+ * Unsubscribe Directives.
  *
- * @param <K> The key
- * @param <X> The value
- * @author Ivan Ivanchuck (l3r8y@duck.com)
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.0.0
+ * @since 0.3.5
  */
-public interface Consumer<K, X> extends Closeable {
+public final class UnsubscribeDirs implements Scalar<Directives> {
 
   /**
-   * Subscribe.
+   * Consumer ID.
+   */
+  private final UUID consumer;
+
+  /**
+   * Ctor.
    *
-   * @param topics topics to subscribe
+   * @param cnsmr Consumer ID
    */
-  void subscribe(String... topics);
+  public UnsubscribeDirs(final UUID cnsmr) {
+    this.consumer = cnsmr;
+  }
 
-  /**
-   * Subscribe.
-   *
-   * @param topics topics to subscribe
-   */
-  void subscribe(Collection<String> topics);
-
-  /**
-   * Subscribe.
-   *
-   * @param listener rebalance listener
-   * @param topics   topics to subscribe
-   */
-  void subscribe(ConsumerRebalanceListener listener, String... topics);
-
-  /**
-   * Fetch Records.
-   *
-   * @param topic   topic to poll
-   * @param timeout max time to wait
-   * @return Records.
-   */
-  ConsumerRecords<K, X> records(String topic, Duration timeout);
-
-  /**
-   * Unsubscribe.
-   * @throws Exception When something went wrong.
-   */
-  void unsubscribe() throws Exception;
+  @Override
+  public Directives value() throws Exception {
+    return new Directives()
+      .xpath("broker/subs/sub[consumer = '%s']/consumer"
+        .formatted(
+          this.consumer
+        )
+      )
+      .remove()
+      .remove();
+  }
 }

--- a/src/test/java/io/github/eocqrs/kafka/fake/UnsubscribeDirsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/UnsubscribeDirsTest.java
@@ -1,0 +1,53 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.fake;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import java.util.UUID;
+
+/**
+ * Test case for {@link UnsubscribeDirs}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+final class UnsubscribeDirsTest {
+
+  @Test
+  void dirsInRightFormat() throws Exception {
+    final UUID uuid = UUID.fromString("1ce12119-7ccc-46fc-a993-36d5b815a7b5");
+    final String directives = "XPATH \"broker/subs/sub"
+      + "[consumer = &apos;1ce12119-7ccc-46fc-a993-36d5b815a7b5&apos;]/consumer\";"
+      + "\n1:REMOVE;REMOVE;";
+    MatcherAssert.assertThat(
+      "Directives in right format",
+      new UnsubscribeDirs(uuid)
+        .value()
+        .toString(),
+      Matchers.equalTo(directives)
+    );
+  }
+}


### PR DESCRIPTION
@l3r8yJ take a look, please

closes #371 #297 

<!-- start pr-codex -->

## PR-Codex overview
This PR implements the `unsubscribe()` method for the `FkConsumer` class in the `io.github.eocqrs.kafka.fake` package. 

### Detailed summary
- Adds `unsubscribe()` method to `FkConsumer` class.
- Implements `UnsubscribeDirs` class to handle the `unsubscribe()` method.
- Adds tests for `unsubscribe()` method and `UnsubscribeDirs` class.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->