### PR TITLE
Fake consumer records

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/Consumer.java
+++ b/src/main/java/io/github/eocqrs/kafka/Consumer.java
@@ -68,11 +68,14 @@ public interface Consumer<K, X> extends Closeable {
    * @param topic   topic to poll
    * @param timeout max time to wait
    * @return Records.
+   * @throws Exception When something went wrong.
    */
-  ConsumerRecords<K, X> records(String topic, Duration timeout);
+  ConsumerRecords<K, X> records(String topic, Duration timeout)
+    throws Exception;
 
   /**
    * Unsubscribe.
+   *
    * @throws Exception When something went wrong.
    */
   void unsubscribe() throws Exception;

--- a/src/main/java/io/github/eocqrs/kafka/fake/DatasetDirs.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/DatasetDirs.java
@@ -74,6 +74,9 @@ public final class DatasetDirs<K, X> implements Scalar<Directives> {
       .set(this.key)
       .up()
       .addIf("value")
-      .set(this.data.dataized().dataize());
+      .set(this.data.dataized().dataize())
+      .up()
+      .addIf("seen")
+      .set("false");
   }
 }

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkRecords.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkRecords.java
@@ -1,0 +1,77 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.fake;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.TopicPartition;
+import org.cactoos.Scalar;
+import org.cactoos.list.ListOf;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Fake Records.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+public final class FkRecords implements
+  Scalar<ConsumerRecords<Object, String>> {
+
+  public static final int DEFAULT_PARTITION = 0;
+  public static final long ZERO_OFFSET = 0L;
+  private final String topic;
+  private final Collection<String> datasets;
+
+  public FkRecords(
+    final String tpc,
+    final Collection<String> dtst
+  ) {
+    this.topic = tpc;
+    this.datasets = dtst;
+  }
+
+  @Override
+  public ConsumerRecords<Object, String> value() throws Exception {
+    final Map<TopicPartition, List<ConsumerRecord<Object, String>>> part
+      = new HashMap<>();
+    final List<ConsumerRecord<Object, String>> recs = new ListOf<>();
+    this.datasets.forEach(
+      dataset -> recs.add(
+        new ConsumerRecord<>(
+          this.topic,
+          DEFAULT_PARTITION,
+          ZERO_OFFSET,
+          null,
+          dataset
+        )
+      )
+    );
+    part.put(new TopicPartition(this.topic, DEFAULT_PARTITION), recs);
+    return new ConsumerRecords<>(part);
+  }
+}

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkRecords.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkRecords.java
@@ -42,11 +42,32 @@ import java.util.Map;
 public final class FkRecords implements
   Scalar<ConsumerRecords<Object, String>> {
 
+  /*
+   * @todo #303:45m/DEV multi partitioning is not supported
+   */
+  /**
+   * Default Partition.
+   */
   private static final int DEFAULT_PARTITION = 0;
+  /**
+   * Zero Offset.
+   */
   private static final long ZERO_OFFSET = 0L;
+  /**
+   * Records related to a topic.
+   */
   private final String topic;
+  /**
+   * Dataset to transform.
+   */
   private final Collection<String> datasets;
 
+  /**
+   * Ctor.
+   *
+   * @param tpc  Topic
+   * @param dtst Dataset to transform
+   */
   public FkRecords(
     final String tpc,
     final Collection<String> dtst

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkRecords.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkRecords.java
@@ -79,7 +79,7 @@ public final class FkRecords implements
   @Override
   public ConsumerRecords<Object, String> value() throws Exception {
     final Map<TopicPartition, List<ConsumerRecord<Object, String>>> part
-      = new HashMap<>();
+      = new HashMap<>(0);
     final List<ConsumerRecord<Object, String>> recs = new ListOf<>();
     this.datasets.forEach(
       dataset -> recs.add(

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkRecords.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkRecords.java
@@ -42,8 +42,8 @@ import java.util.Map;
 public final class FkRecords implements
   Scalar<ConsumerRecords<Object, String>> {
 
-  public static final int DEFAULT_PARTITION = 0;
-  public static final long ZERO_OFFSET = 0L;
+  private static final int DEFAULT_PARTITION = 0;
+  private static final long ZERO_OFFSET = 0L;
   private final String topic;
   private final Collection<String> datasets;
 

--- a/src/main/java/io/github/eocqrs/kafka/fake/SeenDirs.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/SeenDirs.java
@@ -33,9 +33,21 @@ import org.xembly.Directives;
  */
 public final class SeenDirs implements Scalar<Directives> {
 
+  /**
+   * Topic.
+   */
   private final String topic;
+  /**
+   * Fetched value.
+   */
   private final String fetched;
 
+  /**
+   * Ctor.
+   *
+   * @param tpc Topic
+   * @param ftcd Fetched value
+   */
   public SeenDirs(final String tpc, final String ftcd) {
     this.topic = tpc;
     this.fetched = ftcd;

--- a/src/main/java/io/github/eocqrs/kafka/fake/SeenDirs.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/SeenDirs.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.fake;
+
+import org.cactoos.Scalar;
+import org.xembly.Directives;
+
+/**
+ * Seen Directives.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+public final class SeenDirs implements Scalar<Directives> {
+
+  private final String topic;
+  private final String fetched;
+
+  public SeenDirs(final String tpc, final String ftcd) {
+    this.topic = tpc;
+    this.fetched = ftcd;
+  }
+
+  @Override
+  public Directives value() throws Exception {
+    return new Directives()
+      .xpath(
+        ("broker/topics/topic[name = '%s']/datasets/dataset[value = '%s'"
+          + " and seen = 'false']/seen/text()")
+          .formatted(
+            this.topic,
+            this.fetched
+          )
+      )
+      .set("true");
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/fake/DatasetDirsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/DatasetDirsTest.java
@@ -17,7 +17,8 @@ final class DatasetDirsTest {
   void dirsInRightFormat() throws Exception {
     final String directives = "XPATH \"broker/topics/topic[name = &apos;&apos;]\";ADDIF "
       + "\"datasets\";ADD \"dataset\";ADD \"partition\";\n"
-      + "4:SET \"0\";UP;ADDIF \"key\";SET \"test\";UP;ADDIF \"value\";SET \"\";";
+      + "4:SET \"0\";UP;ADDIF \"key\";SET \"test\";UP;ADDIF \"value\";SET \"\";"
+      + "UP;ADDIF \"seen\";SET \"false\";";
     MatcherAssert.assertThat(
       "Directives in the right format",
       new DatasetDirs<>(

--- a/src/test/java/io/github/eocqrs/kafka/fake/FkRecordsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/FkRecordsTest.java
@@ -1,0 +1,70 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.fake;
+
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import java.util.function.Consumer;
+
+/**
+ * Test case for {@link FkRecords}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+final class FkRecordsTest {
+
+  @Test
+  void readsRecordsInRightFormat() throws Exception {
+    final String topic = "test";
+    final String value = "test";
+    new FkRecords(topic, new ListOf<>(value))
+      .value()
+      .forEach(rec ->
+        MatcherAssert.assertThat(
+          "Records in right format",
+          rec.value(),
+          Matchers.equalTo(value)
+        ));
+  }
+
+  @Test
+  void readsCountInRightFormat() throws Exception {
+    final String topic = "test";
+    MatcherAssert.assertThat(
+      "Records Count in right format",
+      new FkRecords(
+        topic,
+        new ListOf<>(
+          "first",
+          "second"
+        )
+      ).value().count(),
+      Matchers.equalTo(2)
+    );
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/fake/SeenDirsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/SeenDirsTest.java
@@ -1,0 +1,54 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.fake;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link SeenDirs}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+final class SeenDirsTest {
+
+  @Test
+  void dirsInRightFormat() throws Exception {
+    final String directives = "XPATH \"broker/topics/topic[name = &apos;test&apos;]"
+      + "/datasets/dataset[value = &apos;test&apos;"
+      + " and seen = &apos;false&apos;]/seen/text()\";\n"
+      + "1:SET \"true\";";
+    MatcherAssert.assertThat(
+      "Directives in the right format",
+      new SeenDirs(
+        "test",
+        "test"
+      ).value().toString(),
+      Matchers.equalTo(
+        directives
+      )
+    );
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/parameters/KfFlexibleEnvelopeTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/parameters/KfFlexibleEnvelopeTest.java
@@ -1,0 +1,50 @@
+package io.github.eocqrs.kafka.parameters;
+
+import io.github.eocqrs.kafka.Params;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.cactoos.map.MapOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test case for {@link KfFlexibleEnvelope}.
+ *
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.3.5
+ */
+final class KfFlexibleEnvelopeTest {
+
+  @Test
+  void createsWithEnvelope() {
+    final KfFlexibleEnvelope<String, String> envelope =
+      new KfFlexibleEnvelopeTest.Example(
+        new KfParams(
+          new ClientId("test")
+        )
+      );
+    MatcherAssert.assertThat(
+      "Creates with Envelope",
+      envelope,
+      Matchers.notNullValue()
+    );
+  }
+
+  private static class Example extends KfFlexibleEnvelope<String, String> {
+
+    protected Example(final Params params) {
+      super(params);
+    }
+
+    @Override
+    public KafkaConsumer<String, String> consumer() {
+      return new KafkaConsumer<>(new MapOf<>());
+    }
+
+    @Override
+    public KafkaProducer<String, String> producer() {
+      return new KafkaProducer<>(new MapOf<>());
+    }
+  }
+}


### PR DESCRIPTION
@l3r8yJ take a look, please

closes #303

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds functionality to the Kafka fake consumer, including support for various data types and a timeout for reading records. It also includes some minor changes and bug fixes.

### Detailed summary
- Added support for various data types in the Kafka fake consumer.
- Added a timeout for reading records in the Kafka fake consumer.
- Minor changes and bug fixes in various files.

> The following files were skipped due to too many changes: `src/main/java/io/github/eocqrs/kafka/fake/FkRecords.java`, `src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->