### PR TITLE
fail on ci false

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -25,4 +25,4 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./target/site/jacoco/jacoco.xml
-          fail_ci_if_error: true
+          fail_ci_if_error: false


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR changes the `fail_ci_if_error` value from `true` to `false` in the `.github/workflows/codecov.yml` file.

### Detailed summary
- Changes the `fail_ci_if_error` value from `true` to `false` in the `.github/workflows/codecov.yml` file.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->