### PR TITLE
flexible message producing

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,21 +64,45 @@ dependencies {
 ```
 
 ## Messages API
-To create Kafka Message:
+To create Kafka Message with **Topic**, **Key** and **Value**:
 ```java
-Data<String> string =
-  new KfData<>(
-    "string-data",          //data
-    "strings",              //topic
-    1                       //partition
+final Message<String, String> msg = new Tkv<>("test.topic", "test-k", "test-v");
+```
+
+Creation Kafka Message with **Partition**:
+```java
+final Message<String, String> msg = 
+  new WithPartition<>(
+    0,
+    new Tkv<>(
+      "test.topic",
+      "test-k",
+      "test-v"
+    )
   );
+```
+
+Creation Kafka Message with **Timestamp**:
+```java
+final Message<String, String> msg =
+  new Timestamped<>(
+      tmstmp,
+      new WithPartition<>(
+        partition,
+        new Tkv<>(
+          topic,
+          key,
+          value
+        )
+    )
+);
 ```
 
 ## Producer API
 To create Kafka Producer you can wrap original [KafkaProducer](https://kafka.apache.org/23/javadoc/index.html?org/apache/kafka/clients/producer/KafkaProducer.html):
 ```java
-KafkaProducer origin = ...;
-Producer<String, String> producer = new KfProducer<>(origin);
+final KafkaProducer origin = ...;
+final Producer<String, String> producer = new KfProducer<>(origin);
 ```
 Or construct it with [KfFlexible](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/KfFlexible.java):
 ```java
@@ -115,13 +139,15 @@ To send a [message](#messages-api):
 ```java
 try (final Producer<String, String> producer = ...) {
       producer.send(
-        "key2012",
-        new KfData<>(
-          "newRest28",
-          "orders",
-          1
+        new WithPartition<>(
+          0,
+          new Tkv<>(
+            "xyz.topic",
+            "key",
+            "message"
         )
-      );
+      )
+    );
     } catch (Exception e) {
         throw new IllegalStateException(e);
   }
@@ -151,8 +177,8 @@ final Producer<String, String> producer =
 ## Consumer API
 To create Kafka Consumer you can wrap original [KafkaConsumer](https://kafka.apache.org/23/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html):
 ```java
-KafkaConsumer origin = ...;
-Consumer<String, String> producer = new KfConsumer<>(origin);
+final KafkaConsumer origin = ...;
+final Consumer<String, String> producer = new KfConsumer<>(origin);
 ```
 Using [KfFlexible](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/KfFlexible.java):
 ```java
@@ -311,9 +337,36 @@ final Consumer<Object, String> consumer =
    );
 final Producer<String, String> producer =
    new FkProducer<>(UUID.randomUUID(), this.broker);
-producer.send("test1", new KfData<>("test-data-1", topic, 0));
-producer.send("test2", new KfData<>("test-data-2", topic, 0));
-producer.send("test3", new KfData<>("test-data-3", topic, 0));
+producer.send(
+  new WithPartition<>(
+      0,
+      new Tkv<>(
+        topic,
+        "test1",
+        "test-data-1"
+      )
+    )
+);
+producer.send(
+  new WithPartition<>(
+      0,
+      new Tkv<>(
+        topic,
+        "test2",
+        "test-data-2"
+      )
+    )
+);
+producer.send(
+  new WithPartition<>(
+      0,
+      new Tkv<>(
+        topic,
+        "test-data-3",
+        "test3"
+      )
+    )
+);
 final ConsumerRecords<Object, String> records =
    consumer.records(topic, Duration.ofSeconds(1L));
 final List<String> datasets = new ListOf<>();

--- a/src/it/producer-consumer-api/pom.xml
+++ b/src/it/producer-consumer-api/pom.xml
@@ -42,11 +42,16 @@ SOFTWARE.
     <testcontainers.version>1.18.3</testcontainers.version>
   </properties>
   <dependencies>
+<!--    <dependency>-->
+<!--      <groupId>@project.groupId@</groupId>-->
+<!--      <artifactId>@project.artifactId@</artifactId>-->
+<!--      <version>@project.version@</version>-->
+<!--      <scope>test</scope>-->
+<!--    </dependency>-->
     <dependency>
-      <groupId>@project.groupId@</groupId>
-      <artifactId>@project.artifactId@</artifactId>
-      <version>@project.version@</version>
-      <scope>test</scope>
+      <groupId>io.github.eo-cqrs</groupId>
+      <artifactId>eo-kafka</artifactId>
+      <version>1.0-SNAPSHOT</version>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
@@ -105,6 +110,12 @@ SOFTWARE.
       <groupId>org.mockito</groupId>
       <artifactId>mockito-core</artifactId>
       <version>${mockito-core.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.github.eo-cqrs</groupId>
+      <artifactId>eo-kafka</artifactId>
+      <version>1.0-SNAPSHOT</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/it/producer-consumer-api/pom.xml
+++ b/src/it/producer-consumer-api/pom.xml
@@ -42,16 +42,11 @@ SOFTWARE.
     <testcontainers.version>1.18.3</testcontainers.version>
   </properties>
   <dependencies>
-<!--    <dependency>-->
-<!--      <groupId>@project.groupId@</groupId>-->
-<!--      <artifactId>@project.artifactId@</artifactId>-->
-<!--      <version>@project.version@</version>-->
-<!--      <scope>test</scope>-->
-<!--    </dependency>-->
     <dependency>
-      <groupId>io.github.eo-cqrs</groupId>
-      <artifactId>eo-kafka</artifactId>
-      <version>1.0-SNAPSHOT</version>
+      <groupId>@project.groupId@</groupId>
+      <artifactId>@project.artifactId@</artifactId>
+      <version>@project.version@</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>

--- a/src/it/producer-consumer-api/src/test/java/EntryTest.java
+++ b/src/it/producer-consumer-api/src/test/java/EntryTest.java
@@ -27,6 +27,8 @@ import io.github.eocqrs.kafka.Producer;
 import io.github.eocqrs.kafka.consumer.KfConsumer;
 import io.github.eocqrs.kafka.consumer.settings.KfConsumerParams;
 import io.github.eocqrs.kafka.data.KfData;
+import io.github.eocqrs.kafka.data.Tkv;
+import io.github.eocqrs.kafka.data.WithPartition;
 import io.github.eocqrs.kafka.parameters.AutoOffsetReset;
 import io.github.eocqrs.kafka.parameters.BootstrapServers;
 import io.github.eocqrs.kafka.parameters.ClientId;
@@ -175,8 +177,14 @@ final class EntryTest {
     ) {
       Assertions.assertDoesNotThrow(
         () -> producer.send(
-          "fake-key",
-          new KfData<>("fake-data", "FAKE-TOPIC", 1)
+          new WithPartition<>(
+            1,
+            new Tkv<>(
+              "FAKE-TOPIC",
+              "fake-key",
+              "fake-data"
+            )
+          )
         )
       );
     }
@@ -212,7 +220,16 @@ final class EntryTest {
           )
         )
       );
-    producer.send("testcontainers", new KfData<>("rulezzz", "TEST-TOPIC", 0));
+    producer.send(
+      new WithPartition<>(
+        0,
+        new Tkv<>(
+          "TEST-TOPIC",
+          "testcontainers",
+          "rulezzz"
+        )
+      )
+    );
     Unreliables.retryUntilTrue(
       10,
       TimeUnit.SECONDS,
@@ -256,8 +273,14 @@ final class EntryTest {
         )
     ) {
       producer.send(
-        "test-key",
-        new KfData<>("test-data", "TEST-CALLBACK", 1)
+        new WithPartition<>(
+          1,
+          new Tkv<>(
+            "TEST-CALLBACK",
+            "test-key",
+            "test-data"
+          )
+        )
       );
     }
   }

--- a/src/it/producer-consumer-api/src/test/java/ProducerConsumerTest.java
+++ b/src/it/producer-consumer-api/src/test/java/ProducerConsumerTest.java
@@ -26,7 +26,6 @@ import io.github.eocqrs.kafka.Consumer;
 import io.github.eocqrs.kafka.Producer;
 import io.github.eocqrs.kafka.consumer.KfConsumer;
 import io.github.eocqrs.kafka.consumer.settings.KfConsumerParams;
-import io.github.eocqrs.kafka.data.KfData;
 import io.github.eocqrs.kafka.parameters.AutoOffsetReset;
 import io.github.eocqrs.kafka.parameters.BootstrapServers;
 import io.github.eocqrs.kafka.parameters.ClientId;
@@ -38,6 +37,8 @@ import io.github.eocqrs.kafka.parameters.KfParams;
 import io.github.eocqrs.kafka.parameters.ValueDeserializer;
 import io.github.eocqrs.kafka.parameters.ValueSerializer;
 import io.github.eocqrs.kafka.producer.KfProducer;
+import io.github.eocqrs.kafka.data.Tkv;
+import io.github.eocqrs.kafka.data.WithPartition;
 import io.github.eocqrs.kafka.producer.settings.KfProducerParams;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -93,7 +94,16 @@ final class ProducerConsumerTest extends KafkaITCase {
           )
         )
       );
-    producer.send(key, new KfData<>(value, topic, 0));
+    producer.send(
+      new WithPartition<>(
+        0,
+        new Tkv<>(
+          topic,
+          key,
+          value
+        )
+      )
+    );
     Unreliables.retryUntilTrue(
       10,
       TimeUnit.SECONDS,

--- a/src/it/producer-consumer-api/src/test/java/ProducerTest.java
+++ b/src/it/producer-consumer-api/src/test/java/ProducerTest.java
@@ -23,7 +23,6 @@
  */
 
 import io.github.eocqrs.kafka.Producer;
-import io.github.eocqrs.kafka.data.KfData;
 import io.github.eocqrs.kafka.parameters.BootstrapServers;
 import io.github.eocqrs.kafka.parameters.KeySerializer;
 import io.github.eocqrs.kafka.parameters.KfFlexible;
@@ -31,6 +30,8 @@ import io.github.eocqrs.kafka.parameters.KfParams;
 import io.github.eocqrs.kafka.parameters.ValueSerializer;
 import io.github.eocqrs.kafka.producer.KfCallback;
 import io.github.eocqrs.kafka.producer.KfProducer;
+import io.github.eocqrs.kafka.data.Tkv;
+import io.github.eocqrs.kafka.data.WithPartition;
 import io.github.eocqrs.kafka.producer.settings.KfProducerParams;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -41,6 +42,7 @@ import java.io.IOException;
 
 /**
  * Kafka Producer IT Case
+ *
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.2.3
  */
@@ -64,8 +66,14 @@ final class ProducerTest extends KafkaITCase {
     ) {
       Assertions.assertDoesNotThrow(
         () -> producer.send(
-          "fake-key",
-          new KfData<>("fake-data", "FAKE-TOPIC", 1)
+          new WithPartition<>(
+            1,
+            new Tkv<>(
+              "FAKE-TOPIC",
+              "fake-key",
+              "fake-data"
+            )
+          )
         )
       );
     }
@@ -73,6 +81,9 @@ final class ProducerTest extends KafkaITCase {
 
   @Test
   void createsProducerAndSendsDataWithCallback() throws Exception {
+    final String topic = "TEST-CALLBACK";
+    final String key = "test-key";
+    final String value = "test-data";
     try (
       final Producer<String, String> producer =
         new KfCallback<>(
@@ -88,13 +99,19 @@ final class ProducerTest extends KafkaITCase {
           (recordMetadata, e) ->
             MatcherAssert.assertThat(
               recordMetadata.topic(),
-              Matchers.equalTo("TEST-CALLBACK")
+              Matchers.equalTo(topic)
             )
         )
     ) {
       producer.send(
-        "test-key",
-        new KfData<>("test-data", "TEST-CALLBACK", 1)
+        new WithPartition<>(
+          1,
+          new Tkv<>(
+            topic,
+            key,
+            value
+          )
+        )
       );
     }
   }

--- a/src/main/java/io/github/eocqrs/kafka/Data.java
+++ b/src/main/java/io/github/eocqrs/kafka/Data.java
@@ -28,7 +28,9 @@ package io.github.eocqrs.kafka;
  * @param <X> The value
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.0.0
+ * @deprecated since 0.3.6, use {@link Message} instead.
  */
+@Deprecated(since = "0.3.6")
 public interface Data<X> {
 
   /**

--- a/src/main/java/io/github/eocqrs/kafka/Message.java
+++ b/src/main/java/io/github/eocqrs/kafka/Message.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -22,27 +22,19 @@
 
 package io.github.eocqrs.kafka;
 
-import java.io.Closeable;
-import java.util.concurrent.Future;
-
-import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.cactoos.Scalar;
 
 /**
- * Producer.
+ * Kafka Message.
  *
  * @param <K> The key
  * @param <X> The value
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.0.0
+ * @since 0.3.6
  */
-public interface Producer<K, X> extends Closeable {
+public interface Message<K, X> extends Scalar<ProducerRecord<K, X>> {
 
-  /**
-   * Send message.
-   *
-   * @param message Message
-   * @return Future with RecordMetadata.
-   * @throws Exception When something went wrong.
-   */
-  Future<RecordMetadata> send(Message<K, X> message) throws Exception;
+  @Override
+  ProducerRecord<K, X> value() throws Exception;
 }

--- a/src/main/java/io/github/eocqrs/kafka/data/KfData.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/KfData.java
@@ -34,6 +34,7 @@ import lombok.RequiredArgsConstructor;
  * @since 0.0.0
  */
 @RequiredArgsConstructor
+@Deprecated(since = "0.3.6")
 public final class KfData<X> implements Data<X> {
 
   /**

--- a/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,29 +20,52 @@
  * SOFTWARE.
  */
 
-package io.github.eocqrs.kafka;
+package io.github.eocqrs.kafka.data;
 
-import java.io.Closeable;
-import java.util.concurrent.Future;
-
-import org.apache.kafka.clients.producer.RecordMetadata;
+import io.github.eocqrs.kafka.Message;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
 /**
- * Producer.
+ * Message with timestamp.
  *
  * @param <K> The key
  * @param <X> The value
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.0.0
+ * @since 0.3.6
  */
-public interface Producer<K, X> extends Closeable {
+public final class Timestamped<K, X> implements Message<K, X> {
 
   /**
-   * Send message.
-   *
-   * @param message Message
-   * @return Future with RecordMetadata.
-   * @throws Exception When something went wrong.
+   * Timestamp.
    */
-  Future<RecordMetadata> send(Message<K, X> message) throws Exception;
+  private final long timestamp;
+  /**
+   * Message.
+   */
+  private final Message<K, X> message;
+
+  /**
+   * Ctor.
+   *
+   * @param tmstmp Timestamp
+   * @param msg    Message
+   */
+  public Timestamped(
+    final long tmstmp,
+    final Message<K, X> msg
+  ) {
+    this.timestamp = tmstmp;
+    this.message = msg;
+  }
+
+  @Override
+  public ProducerRecord<K, X> value() throws Exception {
+    return new ProducerRecord<>(
+      this.message.value().topic(),
+      this.message.value().partition(),
+      this.timestamp,
+      this.message.value().key(),
+      this.message.value().value()
+    );
+  }
 }

--- a/src/main/java/io/github/eocqrs/kafka/data/Tkv.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/Tkv.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,29 +20,57 @@
  * SOFTWARE.
  */
 
-package io.github.eocqrs.kafka;
+package io.github.eocqrs.kafka.data;
 
-import java.io.Closeable;
-import java.util.concurrent.Future;
-
-import org.apache.kafka.clients.producer.RecordMetadata;
+import io.github.eocqrs.kafka.Message;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
 /**
- * Producer.
+ * Topic, Key, Value.
  *
  * @param <K> The key
  * @param <X> The value
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.0.0
+ * @since 0.3.6
  */
-public interface Producer<K, X> extends Closeable {
+public final class Tkv<K, X> implements Message<K, X> {
 
   /**
-   * Send message.
-   *
-   * @param message Message
-   * @return Future with RecordMetadata.
-   * @throws Exception When something went wrong.
+   * Topic.
    */
-  Future<RecordMetadata> send(Message<K, X> message) throws Exception;
+  private final String topic;
+  /**
+   * Key.
+   */
+  private final K key;
+  /**
+   * Value.
+   */
+  private final X value;
+
+  /**
+   * Ctor.
+   *
+   * @param tpc Topic
+   * @param key Key
+   * @param val Value
+   */
+  public Tkv(
+    final String tpc,
+    final K key,
+    final X val
+  ) {
+    this.topic = tpc;
+    this.key = key;
+    this.value = val;
+  }
+
+  @Override
+  public ProducerRecord<K, X> value() throws Exception {
+    return new ProducerRecord<>(
+      this.topic,
+      this.key,
+      this.value
+    );
+  }
 }

--- a/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,29 +20,51 @@
  * SOFTWARE.
  */
 
-package io.github.eocqrs.kafka;
+package io.github.eocqrs.kafka.data;
 
-import java.io.Closeable;
-import java.util.concurrent.Future;
-
-import org.apache.kafka.clients.producer.RecordMetadata;
+import io.github.eocqrs.kafka.Message;
+import org.apache.kafka.clients.producer.ProducerRecord;
 
 /**
- * Producer.
+ * Message with specified partition.
  *
  * @param <K> The key
  * @param <X> The value
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.0.0
+ * @since 0.3.6
  */
-public interface Producer<K, X> extends Closeable {
+public final class WithPartition<K, X> implements Message<K, X> {
 
   /**
-   * Send message.
-   *
-   * @param message Message
-   * @return Future with RecordMetadata.
-   * @throws Exception When something went wrong.
+   * Partition.
    */
-  Future<RecordMetadata> send(Message<K, X> message) throws Exception;
+  private final int partition;
+  /**
+   * Message.
+   */
+  private final Message<K, X> message;
+
+  /**
+   * Ctor.
+   *
+   * @param prtn Partition
+   * @param msg  Message
+   */
+  public WithPartition(
+    final int prtn,
+    final Message<K, X> msg
+  ) {
+    this.partition = prtn;
+    this.message = msg;
+  }
+
+  @Override
+  public ProducerRecord<K, X> value() throws Exception {
+    return new ProducerRecord<>(
+      this.message.value().topic(),
+      this.partition,
+      this.message.value().key(),
+      this.message.value().value()
+    );
+  }
 }

--- a/src/main/java/io/github/eocqrs/kafka/fake/DatasetDirs.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/DatasetDirs.java
@@ -34,6 +34,7 @@ import org.xembly.Directives;
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.3.5
  */
+@SuppressWarnings("deprecation")
 public final class DatasetDirs<K, X> implements Scalar<Directives> {
 
   /**

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
@@ -23,8 +23,10 @@
 package io.github.eocqrs.kafka.fake;
 
 import com.jcabi.log.Logger;
-import io.github.eocqrs.kafka.Data;
 import io.github.eocqrs.kafka.Producer;
+import io.github.eocqrs.kafka.data.KfData;
+import io.github.eocqrs.kafka.Message;
+import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
 import org.apache.kafka.common.TopicPartition;
 
@@ -77,31 +79,35 @@ public final class FkProducer<K, X> implements Producer<K, X> {
 
   @Override
   public Future<RecordMetadata> send(
-    final K key,
-    final Data<X> message
+    final Message<K, X> message
   ) throws Exception {
+    final ProducerRecord<K, X> record = message.value();
     new ThrowsOnFalse(
-      new TopicExists(message.topic(), this.broker),
+      new TopicExists(record.topic(), this.broker),
       "topic %s does not exists!"
         .formatted(
-          message.topic()
+          record.topic()
         )
     ).value();
-    this.broker.with(new DatasetDirs<>(key, message).value());
+    this.broker.with(
+      new DatasetDirs<>(record.key(),
+        new KfData<>(
+          record.value(),
+          record.topic(),
+          record.partition()
+        )
+      ).value()
+    );
     final RecordMetadata metadata = new RecordMetadata(
       new TopicPartition(
-        message.topic(),
-        message.partition()
+        record.topic(),
+        record.partition()
       ),
       OFFSET,
       BATCH_INDEX,
       TIMESTAMP,
-      key.toString().getBytes().length,
-      message.dataized()
-        .dataize()
-        .toString()
-        .getBytes()
-        .length
+      record.key().toString().getBytes().length,
+      record.value().toString().getBytes().length
     );
     return new FkMetadataTask(
       metadata

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java
@@ -43,6 +43,7 @@ import java.util.concurrent.Future;
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.0.0
  */
+@SuppressWarnings("deprecation")
 public final class FkProducer<K, X> implements Producer<K, X> {
 
   /**

--- a/src/main/java/io/github/eocqrs/kafka/producer/KfCallback.java
+++ b/src/main/java/io/github/eocqrs/kafka/producer/KfCallback.java
@@ -24,14 +24,14 @@
 
 package io.github.eocqrs.kafka.producer;
 
-import io.github.eocqrs.kafka.Data;
+import io.github.eocqrs.kafka.Message;
 import io.github.eocqrs.kafka.Producer;
 import io.github.eocqrs.kafka.ProducerSettings;
-import java.util.concurrent.Future;
 import org.apache.kafka.clients.producer.Callback;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
 import org.apache.kafka.clients.producer.RecordMetadata;
+
+import java.util.concurrent.Future;
 
 /**
  * Kafka Producer with callback, decorator for {@link KafkaProducer}.
@@ -69,7 +69,7 @@ public final class KfCallback<K, X> implements Producer<K, X> {
   /**
    * Primary ctor.
    *
-   * @param origin The origin producer.
+   * @param origin   The origin producer.
    * @param callback The callback
    */
   public KfCallback(final KafkaProducer<K, X> origin, final Callback callback) {
@@ -78,14 +78,10 @@ public final class KfCallback<K, X> implements Producer<K, X> {
   }
 
   @Override
-  public Future<RecordMetadata> send(final K key, final Data<X> data) {
+  public Future<RecordMetadata> send(final Message<K, X> msg)
+    throws Exception {
     return this.origin.send(
-      new ProducerRecord<>(
-        data.topic(),
-        data.partition(),
-        key,
-        data.dataized().dataize()
-      ),
+      msg.value(),
       this.callback
     );
   }

--- a/src/main/java/io/github/eocqrs/kafka/producer/KfProducer.java
+++ b/src/main/java/io/github/eocqrs/kafka/producer/KfProducer.java
@@ -22,15 +22,13 @@
 
 package io.github.eocqrs.kafka.producer;
 
-import io.github.eocqrs.kafka.Data;
+import io.github.eocqrs.kafka.Message;
 import io.github.eocqrs.kafka.Producer;
 import io.github.eocqrs.kafka.ProducerSettings;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.RecordMetadata;
 
 import java.util.concurrent.Future;
-
-import org.apache.kafka.clients.producer.KafkaProducer;
-import org.apache.kafka.clients.producer.ProducerRecord;
-import org.apache.kafka.clients.producer.RecordMetadata;
 
 /**
  * Kafka Producer.
@@ -68,15 +66,9 @@ public final class KfProducer<K, X> implements Producer<K, X> {
   }
 
   @Override
-  public Future<RecordMetadata> send(final K key, final Data<X> data) {
-    return this.origin.send(
-      new ProducerRecord<>(
-        data.topic(),
-        data.partition(),
-        key,
-        data.dataized().dataize()
-      )
-    );
+  public Future<RecordMetadata> send(final Message<K, X> msg)
+    throws Exception {
+    return this.origin.send(msg.value());
   }
 
   @Override

--- a/src/test/java/io/github/eocqrs/kafka/data/KfDataTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/data/KfDataTest.java
@@ -29,11 +29,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
- * Test case for {@link KfData}
+ * Test case for {@link KfData}.
  *
  * @since 0.0.0
  */
-class KfDataTest {
+@SuppressWarnings("deprecation")
+final class KfDataTest {
 
   @Test
   void dataizesFromString() {

--- a/src/test/java/io/github/eocqrs/kafka/data/KfDataizedTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/data/KfDataizedTest.java
@@ -29,11 +29,12 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Test case for {@link KfDataized}
+ * Test case for {@link KfDataized}.
  *
  * @since 0.0.0
  */
-class KfDataizedTest {
+@SuppressWarnings("deprecation")
+final class KfDataizedTest {
 
   @Test
   void dataizesToInt() {

--- a/src/test/java/io/github/eocqrs/kafka/data/TimestampedTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/data/TimestampedTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,29 +20,50 @@
  * SOFTWARE.
  */
 
-package io.github.eocqrs.kafka;
+package io.github.eocqrs.kafka.data;
 
-import java.io.Closeable;
-import java.util.concurrent.Future;
-
-import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
 
 /**
- * Producer.
+ * Test case for {@link Timestamped}.
  *
- * @param <K> The key
- * @param <X> The value
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.0.0
+ * @since 0.3.6
  */
-public interface Producer<K, X> extends Closeable {
+final class TimestampedTest {
 
-  /**
-   * Send message.
-   *
-   * @param message Message
-   * @return Future with RecordMetadata.
-   * @throws Exception When something went wrong.
-   */
-  Future<RecordMetadata> send(Message<K, X> message) throws Exception;
+  @Test
+  void readsRecordInRightFormat() throws Exception {
+    final String topic = "topic";
+    final String key = "test-key";
+    final String value = "test-value";
+    final long tmstmp = 1L;
+    final int partition = 1;
+    MatcherAssert.assertThat(
+      "Record in right format",
+      new Timestamped<>(
+        tmstmp,
+        new WithPartition<>(
+          partition,
+          new Tkv<>(
+            topic,
+            key,
+            value
+          )
+        )
+      ).value(),
+      new IsEqual<>(
+        new ProducerRecord<>(
+          topic,
+          partition,
+          tmstmp,
+          key,
+          value
+        )
+      )
+    );
+  }
 }

--- a/src/test/java/io/github/eocqrs/kafka/data/TkvTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/data/TkvTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,29 +20,32 @@
  * SOFTWARE.
  */
 
-package io.github.eocqrs.kafka;
+package io.github.eocqrs.kafka.data;
 
-import java.io.Closeable;
-import java.util.concurrent.Future;
-
-import org.apache.kafka.clients.producer.RecordMetadata;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
 
 /**
- * Producer.
+ * Test case for {@link Tkv}.
  *
- * @param <K> The key
- * @param <X> The value
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.0.0
+ * @since 0.3.6
  */
-public interface Producer<K, X> extends Closeable {
+final class TkvTest {
 
-  /**
-   * Send message.
-   *
-   * @param message Message
-   * @return Future with RecordMetadata.
-   * @throws Exception When something went wrong.
-   */
-  Future<RecordMetadata> send(Message<K, X> message) throws Exception;
+  @Test
+  void readsRecordInRightFormat() throws Exception {
+    final String topic = "test-t";
+    final String key = "test-k";
+    final String value = "test-v";
+    MatcherAssert.assertThat(
+      "Record in right format",
+      new Tkv<>(topic, key, value).value(),
+      new IsEqual<>(
+        new ProducerRecord<>(topic, key, value)
+      )
+    );
+  }
 }

--- a/src/test/java/io/github/eocqrs/kafka/data/WithPartitionTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/data/WithPartitionTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,29 +20,48 @@
  * SOFTWARE.
  */
 
-package io.github.eocqrs.kafka;
+package io.github.eocqrs.kafka.data;
 
-import java.io.Closeable;
-import java.util.concurrent.Future;
-
-import org.apache.kafka.clients.producer.RecordMetadata;
+import io.github.eocqrs.kafka.Message;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.core.IsEqual;
+import org.junit.jupiter.api.Test;
 
 /**
- * Producer.
+ * Test case for {@link WithPartition}.
  *
- * @param <K> The key
- * @param <X> The value
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.0.0
+ * @since 0.3.6
  */
-public interface Producer<K, X> extends Closeable {
+final class WithPartitionTest {
 
-  /**
-   * Send message.
-   *
-   * @param message Message
-   * @return Future with RecordMetadata.
-   * @throws Exception When something went wrong.
-   */
-  Future<RecordMetadata> send(Message<K, X> message) throws Exception;
+  @Test
+  void readsRecordInRightFormat() throws Exception {
+    final int partition = 1;
+    final String topic = "test";
+    final String key = "test-key";
+    final String value = "test-value";
+    final Message<String, String> message =
+      new Tkv<>(
+        topic,
+        key,
+        value
+      );
+    MatcherAssert.assertThat(
+      "Record in right format",
+      new WithPartition<>(
+        partition,
+        message
+      ).value(),
+      new IsEqual<>(
+        new ProducerRecord<>(
+          topic,
+          partition,
+          key,
+          value
+        )
+      )
+    );
+  }
 }

--- a/src/test/java/io/github/eocqrs/kafka/fake/DatasetDirsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/DatasetDirsTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Test;
  * @author Aliaksei Bialiauski (abialaiuski.dev@gmail.com)
  * @since 0.3.5
  */
+@SuppressWarnings("deprecation")
 final class DatasetDirsTest {
 
   @Test

--- a/src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java
@@ -27,7 +27,8 @@ package io.github.eocqrs.kafka.fake;
 import com.jcabi.log.Logger;
 import io.github.eocqrs.kafka.Consumer;
 import io.github.eocqrs.kafka.Producer;
-import io.github.eocqrs.kafka.data.KfData;
+import io.github.eocqrs.kafka.data.Tkv;
+import io.github.eocqrs.kafka.data.WithPartition;
 import io.github.eocqrs.xfake.InFile;
 import io.github.eocqrs.xfake.Synchronized;
 import org.apache.kafka.clients.consumer.ConsumerRebalanceListener;
@@ -349,9 +350,36 @@ final class FkConsumerTest {
       );
     final Producer<String, String> producer =
       new FkProducer<>(UUID.randomUUID(), this.broker);
-    producer.send("test2", new KfData<>("test2", topic, 0));
-    producer.send("test.new", new KfData<>("test-data.new", topic, 0));
-    producer.send("test.new", new KfData<>("test-data.new", topic, 0));
+    producer.send(
+      new WithPartition<>(
+        0,
+        new Tkv<>(
+          topic,
+          "test1",
+          "test1"
+        )
+      )
+    );
+    producer.send(
+      new WithPartition<>(
+        0,
+        new Tkv<>(
+          topic,
+          "test2",
+          "test2"
+        )
+      )
+    );
+    producer.send(
+      new WithPartition<>(
+        0,
+        new Tkv<>(
+          topic,
+          "test3",
+          "test3"
+        )
+      )
+    );
     final ConsumerRecords<Object, String> first =
       consumer.records(topic, Duration.ofSeconds(1L));
     final ConsumerRecords<Object, String> second =
@@ -361,7 +389,7 @@ final class FkConsumerTest {
     MatcherAssert.assertThat(
       "First datasets in right format",
       datasets,
-      Matchers.contains("test2", "test-data.new", "test-data.new")
+      Matchers.contains("test1", "test2", "test3")
     );
     datasets.clear();
     second.forEach(rec -> datasets.add(rec.value()));

--- a/src/test/java/io/github/eocqrs/kafka/fake/FkProducerTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/FkProducerTest.java
@@ -26,7 +26,8 @@ package io.github.eocqrs.kafka.fake;
 
 import com.jcabi.log.Logger;
 import io.github.eocqrs.kafka.Producer;
-import io.github.eocqrs.kafka.data.KfData;
+import io.github.eocqrs.kafka.data.Tkv;
+import io.github.eocqrs.kafka.data.WithPartition;
 import io.github.eocqrs.xfake.InFile;
 import io.github.eocqrs.xfake.Synchronized;
 import org.apache.kafka.clients.producer.RecordMetadata;
@@ -117,7 +118,16 @@ final class FkProducerTest {
     Assertions.assertThrows(
       IllegalArgumentException.class,
       () ->
-        producer.send("test-key", new KfData<>("data", "does.not.exist", 0))
+        producer.send(
+          new WithPartition<>(
+            0,
+            new Tkv<>(
+              "doesn.not.exist",
+              "test-key",
+              "data"
+            )
+          )
+        )
     );
     producer.close();
   }
@@ -134,7 +144,16 @@ final class FkProducerTest {
         UUID.randomUUID(),
         after
       );
-    producer.send("test-key", new KfData<>(data, topic, partition));
+    producer.send(
+      new WithPartition<>(
+        partition,
+        new Tkv<>(
+          topic,
+          "test-key",
+          data
+        )
+      )
+    );
     MatcherAssert.assertThat(
       "Sent data is not blank",
       after.data(
@@ -160,8 +179,14 @@ final class FkProducerTest {
           .with(new TopicDirs(topic).value())
       );
     final Future<RecordMetadata> future = producer.send(
-      "test-key",
-      new KfData<>("test-data", topic, partition)
+      new WithPartition<>(
+        partition,
+        new Tkv<>(
+          topic,
+          "test-key",
+          "test-data"
+        )
+      )
     );
     final RecordMetadata metadata = future.get();
     MatcherAssert.assertThat(

--- a/src/test/java/io/github/eocqrs/kafka/fake/InXmlTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/InXmlTest.java
@@ -41,6 +41,7 @@ import org.mockito.junit.jupiter.MockitoExtension;
  * @since 0.2.3
  */
 @ExtendWith(MockitoExtension.class)
+@SuppressWarnings("deprecation")
 final class InXmlTest {
 
   /**

--- a/src/test/java/io/github/eocqrs/kafka/producer/KfCallbackTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/producer/KfCallbackTest.java
@@ -25,7 +25,8 @@
 package io.github.eocqrs.kafka.producer;
 
 import io.github.eocqrs.kafka.ProducerSettings;
-import io.github.eocqrs.kafka.data.KfData;
+import io.github.eocqrs.kafka.data.Tkv;
+import io.github.eocqrs.kafka.data.WithPartition;
 import org.apache.kafka.clients.producer.KafkaProducer;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -59,11 +60,13 @@ final class KfCallbackTest {
     ) {
       Assertions.assertDoesNotThrow(
         () -> producer.send(
-          "fake-key",
-          new KfData<>(
-            "fake-data",
-            "fake-topic",
-            101
+          new WithPartition<>(
+            101,
+            new Tkv<>(
+              "fake-topic",
+              "fake-key",
+              "fake-data"
+            )
           )
         )
       );
@@ -89,11 +92,13 @@ final class KfCallbackTest {
     ) {
       Assertions.assertDoesNotThrow(
         () -> producer.send(
-          "fake-key",
-          new KfData<>(
-            "fake-data",
-            "fake-topic",
-            101
+          new WithPartition<>(
+            101,
+            new Tkv<>(
+              "fake-topic",
+              "fake-key",
+              "fake-data"
+            )
           )
         )
       );


### PR DESCRIPTION
closes #304

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on deprecating and replacing certain classes and interfaces in the codebase. 

### Detailed summary
- `KfData` class is deprecated and replaced with `Message` class.
- `DatasetDirs` class is marked as deprecated.
- `Data` interface is deprecated and replaced with `Message` interface.
- Added a new dependency `eo-kafka` in the `pom.xml` file.
- Updated test cases to reflect the changes in the codebase.

> The following files were skipped due to too many changes: `src/main/java/io/github/eocqrs/kafka/Message.java`, `src/main/java/io/github/eocqrs/kafka/fake/FkProducer.java`, `src/it/producer-consumer-api/src/test/java/ProducerTest.java`, `src/test/java/io/github/eocqrs/kafka/data/TkvTest.java`, `src/main/java/io/github/eocqrs/kafka/data/Tkv.java`, `src/test/java/io/github/eocqrs/kafka/data/TimestampedTest.java`, `src/test/java/io/github/eocqrs/kafka/data/WithPartitionTest.java`, `src/main/java/io/github/eocqrs/kafka/data/WithPartition.java`, `src/main/java/io/github/eocqrs/kafka/data/Timestamped.java`, `README.md`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->