### PR TITLE
api off from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ dependencies {
 }
 ```
 
-## Messages API
+## Messages
 To create Kafka Message with **Topic**, **Key** and **Value**:
 ```java
 final Message<String, String> msg = new Tkv<>("test.topic", "test-k", "test-v");
@@ -98,7 +98,7 @@ final Message<String, String> msg =
 );
 ```
 
-## Producer API
+## Producers
 To create Kafka Producer you can wrap original [KafkaProducer](https://kafka.apache.org/23/javadoc/index.html?org/apache/kafka/clients/producer/KafkaProducer.html):
 ```java
 final KafkaProducer origin = ...;
@@ -174,7 +174,7 @@ final Producer<String, String> producer =
 );    
 ```
 
-## Consumer API
+## Consumers
 To create Kafka Consumer you can wrap original [KafkaConsumer](https://kafka.apache.org/23/javadoc/index.html?org/apache/kafka/clients/consumer/KafkaConsumer.html):
 ```java
 final KafkaConsumer origin = ...;
@@ -259,7 +259,7 @@ Finally, you can `unsubscribe`:
 consumer.unsubscribe();
 ```
 
-## Fake API
+## Fakes
 
 In case of mocking eo-kafka, you can use existing Fake Objects from `io.github.eocqrs.kafka.fake` package.
 They look like a normal ones, but instead of talking to real Kafka broker,
@@ -326,7 +326,7 @@ final Consumer<Object, String> consumer =
 );
 ```
 
-### Fake API Example
+### Example with Fakes
 
 ```java
 final String topic = "test";

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,6 @@ SOFTWARE.
     <maven.compiler.target>17</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <kafka-clients.version>3.5.0</kafka-clients.version>
-    <kafka-streams.version>3.5.0</kafka-streams.version>
     <cactoos.version>0.55.0</cactoos.version>
     <lombok.version>1.18.28</lombok.version>
     <junit-api.version>5.9.3</junit-api.version>


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
### Detailed summary
- Updated kafka-clients.version to 3.5.0
- Removed kafka-streams.version
- Updated cactoos.version to 0.55.0
- Updated lombok.version to 1.18.28
- Updated junit-api.version to 5.9.3
- Renamed "Messages API" section to "Messages"
- Renamed "Producer API" section to "Producers"
- Renamed "Consumer API" section to "Consumers"
- Renamed "Fake API" section to "Fakes"
- Added example with fakes in the "Fakes" section

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->