### PR TITLE
KfJsonFlexible

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,23 @@ btw, your [XML](https://en.wikipedia.org/wiki/XML#:~:text=Extensible%20Markup%20
 </producer>
 ```
 
+Since version `0.4.6` you can create Producer with JSON file:
+```java
+final Producer<String, String> producer =
+  new KfProducer<>(
+  new KfJsonFlexible<String, String>("producer.json") // file with producer config  
+);
+```
+
+Your [JSON](https://en.wikipedia.org/wiki/JSON), located in resources directory, should looks like this:
+```json
+{
+  "bootstrapServers": "localhost:9092",
+  "keySerializer": "org.apache.kafka.common.serialization.StringSerializer",
+  "valueSerializer": "org.apache.kafka.common.serialization.StringSerializer"
+}
+```
+
 To send a [message](#messages):
 ```java
 try (final Producer<String, String> producer = ...) {
@@ -213,6 +230,24 @@ Again, [XML](https://en.wikipedia.org/wiki/XML#:~:text=Extensible%20Markup%20Lan
   <keyDeserializer>org.apache.kafka.common.serialization.StringDeserializer</keyDeserializer>
   <valueDeserializer>org.apache.kafka.common.serialization.StringDeserializer</valueDeserializer>
 </consumer>
+```
+
+Since version `0.4.6` you can create Consumer with JSON file:
+```java
+final Consumer<String, String> producer =
+  new KfConsumer<>(
+  new KfJsonFlexible<String, String>("consumer.json") // file with producer config  
+);
+```
+
+Your [JSON](https://en.wikipedia.org/wiki/JSON), located in resources directory, should looks like this:
+```json
+{
+ "bootstrapServers": "localhost:9092",
+ "groupId": "1",
+ "keyDeserializer": "org.apache.kafka.common.serialization.StringDeserializer",
+ "valueDeserializer": "org.apache.kafka.common.serialization.StringDeserializer"
+}
 ```
 
 Consuming [messages](#messages):
@@ -426,7 +461,7 @@ Under the hood XML document will looks like this:
 **By the version `0.3.5`, eo-kafka support only String values in FkConsumer**.
 
 ## Config API
-| Kafka Property                          | eo-kafka API                                                                                                                                                    | XML tag
+| Kafka Property                          | eo-kafka API                                                                                                                                                    | XML/JSON tag
 |-----------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------| ----------------------
 | `bootstrap.servers`                     | [BootstrapServers](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/BootstrapServers.java)                       | bootstrapServers
 | `key.serializer`                        | [KeySerializer](https://github.com/eo-cqrs/eo-kafka/blob/master/src/main/java/io/github/eocqrs/kafka/parameters/KeySerializer.java)                             | keySerializer

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@ SOFTWARE.
     <assert4j-core.version>3.24.2</assert4j-core.version>
     <xfake.version>0.1.2</xfake.version>
     <xembly.version>0.28.1</xembly.version>
+    <eokson.version>0.3.2</eokson.version>
     <maven-surefire-plugin.version>3.1.2</maven-surefire-plugin.version>
     <maven-verifier-plugin.version>1.1</maven-verifier-plugin.version>
     <slf4j.version>2.0.7</slf4j.version>
@@ -124,6 +125,11 @@ SOFTWARE.
       <groupId>io.github.eo-cqrs</groupId>
       <artifactId>xfake</artifactId>
       <version>${xfake.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.github.eo-cqrs</groupId>
+      <artifactId>eokson</artifactId>
+      <version>${eokson.version}</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/main/java/io/github/eocqrs/kafka/json/KfJsonFlexible.java
+++ b/src/main/java/io/github/eocqrs/kafka/json/KfJsonFlexible.java
@@ -1,0 +1,99 @@
+/*
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.json;
+
+import com.jcabi.xml.XMLDocument;
+import io.github.eocqrs.eokson.JsonOf;
+import io.github.eocqrs.eokson.JsonXML;
+import io.github.eocqrs.kafka.ConsumerSettings;
+import io.github.eocqrs.kafka.ProducerSettings;
+import io.github.eocqrs.kafka.xml.ConsumerXmlMapParams;
+import io.github.eocqrs.kafka.xml.ProducerXmlMapParams;
+import lombok.SneakyThrows;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.cactoos.io.ResourceOf;
+
+/**
+ * Allow creating custom Consumer/Producer from JSON.
+ *
+ * @param <K> The key
+ * @param <X> The value
+ * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
+ * @since 0.4.6
+ */
+public final class KfJsonFlexible<K, X>
+  implements ConsumerSettings<K, X>, ProducerSettings<K, X> {
+
+  /**
+   * JSON name.
+   */
+  private final String name;
+
+  /**
+   * Ctor.
+   *
+   * @param nm JSON name
+   */
+  public KfJsonFlexible(final String nm) {
+    this.name = nm;
+  }
+
+  @Override
+  @SneakyThrows
+  public KafkaConsumer<K, X> consumer() {
+    return new KafkaConsumer<>(
+      new ConsumerXmlMapParams(
+        new XMLDocument(
+          new JsonXML(
+            new JsonOf(
+              new ResourceOf(
+                this.name
+              ).stream()
+            ),
+            "consumer"
+          ).asString()
+        )
+      ).value()
+    );
+  }
+
+  @Override
+  @SneakyThrows
+  public KafkaProducer<K, X> producer() {
+    return new KafkaProducer<>(
+      new ProducerXmlMapParams(
+        new XMLDocument(
+          new JsonXML(
+            new JsonOf(
+              new ResourceOf(
+                this.name
+              ).stream()
+            ),
+            "producer"
+          ).asString()
+        )
+      ).value()
+    );
+  }
+}

--- a/src/main/java/io/github/eocqrs/kafka/json/package-info.java
+++ b/src/main/java/io/github/eocqrs/kafka/json/package-info.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,45 +20,10 @@
  * SOFTWARE.
  */
 
-package io.github.eocqrs.kafka.xml;
-
-import com.jcabi.xml.XML;
-import org.cactoos.Input;
-
 /**
- * Producer XML Params.
+ * JSON.
  *
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.0.2
+ * @since 0.4.6
  */
-public final class ProducerXmlMapParams extends XmlMapParams {
-
-  /**
-   * Ctor.
-   *
-   * @param config XML config.
-   */
-  public ProducerXmlMapParams(final XML config) {
-    super(config, KfCustomer.PRODUCER);
-  }
-
-  /**
-   * Ctor.
-   *
-   * @param resource The resource with xml settings.
-   * @throws Exception When something went wrong.
-   */
-  ProducerXmlMapParams(final Input resource) throws Exception {
-    super(resource, KfCustomer.PRODUCER);
-  }
-
-  /**
-   * Ctor.
-   *
-   * @param name Name of the resource.
-   * @throws Exception When something went wrong.
-   */
-  ProducerXmlMapParams(final String name) throws Exception {
-    super(name, KfCustomer.PRODUCER);
-  }
-}
+package io.github.eocqrs.kafka.json;

--- a/src/main/java/io/github/eocqrs/kafka/xml/ConsumerXmlMapParams.java
+++ b/src/main/java/io/github/eocqrs/kafka/xml/ConsumerXmlMapParams.java
@@ -31,14 +31,14 @@ import org.cactoos.Input;
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
  * @since 0.0.2
  */
-final class ConsumerXmlMapParams extends XmlMapParams {
+public final class ConsumerXmlMapParams extends XmlMapParams {
 
   /**
    * Ctor.
    *
    * @param config XML config.
    */
-  ConsumerXmlMapParams(final XML config) {
+  public ConsumerXmlMapParams(final XML config) {
     super(config, KfCustomer.CONSUMER);
   }
 

--- a/src/test/java/io/github/eocqrs/kafka/json/KfJsonFlexibleTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/json/KfJsonFlexibleTest.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *  Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -20,45 +20,32 @@
  * SOFTWARE.
  */
 
-package io.github.eocqrs.kafka.xml;
+package io.github.eocqrs.kafka.json;
 
-import com.jcabi.xml.XML;
-import org.cactoos.Input;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 /**
- * Producer XML Params.
+ * Test case for {@link KfJsonFlexible}.
  *
  * @author Aliaksei Bialiauski (abialiauski.dev@gmail.com)
- * @since 0.0.2
+ * @since 0.4.6
  */
-public final class ProducerXmlMapParams extends XmlMapParams {
+final class KfJsonFlexibleTest {
 
-  /**
-   * Ctor.
-   *
-   * @param config XML config.
-   */
-  public ProducerXmlMapParams(final XML config) {
-    super(config, KfCustomer.PRODUCER);
+  @Test
+  void createsCustomConsumer() {
+    Assertions.assertDoesNotThrow(
+      () -> new KfJsonFlexible<String, String>("consumer.json")
+        .consumer()
+    );
   }
 
-  /**
-   * Ctor.
-   *
-   * @param resource The resource with xml settings.
-   * @throws Exception When something went wrong.
-   */
-  ProducerXmlMapParams(final Input resource) throws Exception {
-    super(resource, KfCustomer.PRODUCER);
-  }
-
-  /**
-   * Ctor.
-   *
-   * @param name Name of the resource.
-   * @throws Exception When something went wrong.
-   */
-  ProducerXmlMapParams(final String name) throws Exception {
-    super(name, KfCustomer.PRODUCER);
+  @Test
+  void createsCustomProducer() {
+    Assertions.assertDoesNotThrow(
+      () -> new KfJsonFlexible<String, String>("producer.json")
+        .producer()
+    );
   }
 }

--- a/src/test/java/io/github/eocqrs/kafka/json/KfJsonFlexibleTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/json/KfJsonFlexibleTest.java
@@ -48,4 +48,22 @@ final class KfJsonFlexibleTest {
         .producer()
     );
   }
+
+  @Test
+  void throwsOnNonExistingProducerFile() {
+    Assertions.assertThrows(
+      Exception.class,
+      () -> new KfJsonFlexible<String, String>("abc.json")
+        .producer()
+    );
+  }
+
+  @Test
+  void throwsOnNonExistingConsumerFile() {
+    Assertions.assertThrows(
+      Exception.class,
+      () -> new KfJsonFlexible<String, String>("cdf.json")
+        .consumer()
+    );
+  }
 }

--- a/src/test/resources/consumer.json
+++ b/src/test/resources/consumer.json
@@ -1,0 +1,6 @@
+{
+  "bootstrapServers": "localhost:9092",
+  "groupId": "1",
+  "keyDeserializer": "org.apache.kafka.common.serialization.StringDeserializer",
+  "valueDeserializer": "org.apache.kafka.common.serialization.StringDeserializer"
+}

--- a/src/test/resources/producer.json
+++ b/src/test/resources/producer.json
@@ -1,0 +1,5 @@
+{
+  "bootstrapServers": "localhost:9092",
+  "keySerializer": "org.apache.kafka.common.serialization.StringSerializer",
+  "valueSerializer": "org.apache.kafka.common.serialization.StringSerializer"
+}


### PR DESCRIPTION
closes #406 

@l3r8yJ take a look, please

<!-- start pr-codex -->

---

## PR-Codex overview
This PR adds support for creating Kafka Consumers and Producers using JSON configuration files. 

### Detailed summary
- Added `KfJsonFlexible` class to create custom Consumer and Producer from JSON files
- Updated documentation with instructions on how to use JSON configuration files for Consumers and Producers

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->