### PR TITLE
284

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,1 @@
+lombok.addLombokGeneratedAnnotation = true

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,7 @@ SOFTWARE.
     <maven-gpg-plugin.version>3.1.0</maven-gpg-plugin.version>
     <mockito-core.version>5.4.0</mockito-core.version>
     <mockito-junit-jupiter.version>5.4.0</mockito-junit-jupiter.version>
+    <snakeyaml.version>2.0</snakeyaml.version>
   </properties>
   <dependencies>
     <dependency>
@@ -139,6 +140,11 @@ SOFTWARE.
       <groupId>com.jcabi.incubator</groupId>
       <artifactId>xembly</artifactId>
       <version>${xembly.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+      <version>${snakeyaml.version}</version>
     </dependency>
     <dependency>
       <groupId>com.jcabi</groupId>

--- a/src/main/java/io/github/eocqrs/kafka/fake/FkRecords.java
+++ b/src/main/java/io/github/eocqrs/kafka/fake/FkRecords.java
@@ -81,21 +81,27 @@ public final class FkRecords implements
    */
   @Override
   public ConsumerRecords<Object, String> value() throws Exception {
-    final Map<TopicPartition, List<ConsumerRecord<Object, String>>> part
-      = new HashMap<>(0);
     final List<ConsumerRecord<Object, String>> recs = new ListOf<>();
     this.datasets.forEach(
       dataset -> recs.add(
         new ConsumerRecord<>(
           this.topic,
-          DEFAULT_PARTITION,
-          ZERO_OFFSET,
+          FkRecords.DEFAULT_PARTITION,
+          FkRecords.ZERO_OFFSET,
           null,
           dataset
         )
       )
     );
-    part.put(new TopicPartition(this.topic, DEFAULT_PARTITION), recs);
+    final Map<TopicPartition, List<ConsumerRecord<Object, String>>> part
+      = new HashMap<>(0);
+    part.put(
+      new TopicPartition(
+        this.topic,
+        FkRecords.DEFAULT_PARTITION
+      ),
+      recs
+    );
     return new ConsumerRecords<>(part);
   }
 }

--- a/src/main/java/io/github/eocqrs/kafka/xml/XmlMapParams.java
+++ b/src/main/java/io/github/eocqrs/kafka/xml/XmlMapParams.java
@@ -28,6 +28,7 @@ import org.cactoos.Input;
 import org.cactoos.Scalar;
 import org.cactoos.io.ResourceOf;
 
+import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
 import java.util.regex.Pattern;
@@ -72,7 +73,7 @@ abstract class XmlMapParams implements Scalar<Map<String, Object>> {
    * A ctor that takes an Input and converts it to XMLDocument.
    *
    * @param resource Resource with settings.
-   * @param cust  Customer type.
+   * @param cust     Customer type.
    * @throws Exception When something went wrong.
    */
   protected XmlMapParams(final Input resource, final KfCustomer cust)
@@ -94,25 +95,27 @@ abstract class XmlMapParams implements Scalar<Map<String, Object>> {
 
   @Override
   public final Map<String, Object> value() throws Exception {
-    return new XMLDocument(this.configuration.toString())
-      .nodes("//%s/*".formatted(this.customer))
-      .stream()
-      .map(Object::toString)
-      .map(XMLDocument::new)
-      .map(xml -> xml.nodes("//*").get(0).node().getNodeName())
-      .collect(
-        Collectors.toMap(
-          name ->
-            XmlMapParams.CAPITALS
-              .matcher(name)
-              .replaceAll(".$1")
-              .toLowerCase(Locale.ROOT),
-          name ->
-            new TextXpath(
-              this.configuration,
-              "//%s".formatted(name)
-            ).toString()
+    return Collections.unmodifiableMap(
+      new XMLDocument(this.configuration.toString())
+        .nodes("//%s/*".formatted(this.customer))
+        .stream()
+        .map(Object::toString)
+        .map(XMLDocument::new)
+        .map(xml -> xml.nodes("//*").get(0).node().getNodeName())
+        .collect(
+          Collectors.toMap(
+            name ->
+              XmlMapParams.CAPITALS
+                .matcher(name)
+                .replaceAll(".$1")
+                .toLowerCase(Locale.ROOT),
+            name ->
+              new TextXpath(
+                this.configuration,
+                "//%s".formatted(name)
+              ).toString()
+          )
         )
-      );
+    );
   }
 }

--- a/src/main/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettings.java
+++ b/src/main/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettings.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.yaml;
+
+import io.github.eocqrs.kafka.ConsumerSettings;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+
+/**
+ * Yaml configuration for consumer.
+ *
+ * @param <K> The key type.
+ * @param <X> The value type.
+ */
+@RequiredArgsConstructor
+public final class KfYamlConsumerSettings<K, X>
+  implements ConsumerSettings<K, X> {
+
+  /**
+   * YAML params.
+   */
+  private final YamlMapParams<K, X> params;
+
+  @Override
+  public KafkaConsumer<K, X> consumer() {
+    return new KafkaConsumer<>(this.params.value());
+  }
+}

--- a/src/main/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettings.java
+++ b/src/main/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettings.java
@@ -1,0 +1,48 @@
+/*
+ *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.yaml;
+
+import io.github.eocqrs.kafka.ProducerSettings;
+import lombok.RequiredArgsConstructor;
+import org.apache.kafka.clients.producer.KafkaProducer;
+
+/**
+ * Yaml configuration for producer.
+ *
+ * @param <K> The key type.
+ * @param <X> The value type.
+ */
+@RequiredArgsConstructor
+public final class KfYamlProducerSettings<K, X>
+  implements ProducerSettings<K, X> {
+
+  /**
+   * YAML params.
+   */
+  private final YamlMapParams<K, X> params;
+
+  @Override
+  public KafkaProducer<K, X> producer() {
+    return new KafkaProducer<>(this.params.value());
+  }
+}

--- a/src/main/java/io/github/eocqrs/kafka/yaml/YamlMapParams.java
+++ b/src/main/java/io/github/eocqrs/kafka/yaml/YamlMapParams.java
@@ -1,0 +1,92 @@
+/*
+ *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.yaml;
+
+import lombok.RequiredArgsConstructor;
+import org.cactoos.Input;
+import org.cactoos.Scalar;
+import org.cactoos.io.ResourceOf;
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class converts a YAML source from
+ * kebab case keys into kafka specific keys Map.
+ *
+ * @param <K> The key type.
+ * @param <X> The value type.
+ */
+@RequiredArgsConstructor
+public class YamlMapParams<K, X> implements Scalar<Map<String, Object>> {
+
+  /**
+   * The config value.
+   */
+  private final Map<String, Object> value;
+
+  /**
+   * Filename ctor.
+   *
+   * @param name Config name
+   * @throws Exception When something went wrong
+   */
+  public YamlMapParams(final String name) throws Exception {
+    this(new ResourceOf(name));
+  }
+
+  /**
+   * Input ctor.
+   *
+   * @param input Input source
+   * @throws Exception When something went wrong
+   */
+  public YamlMapParams(final Input input) throws Exception {
+    this(input.stream());
+  }
+
+  /**
+   * Primary ctor.
+   *
+   * @param stream Input source
+   */
+  public YamlMapParams(final InputStream stream) {
+    this.value = new Yaml().load(stream);
+  }
+
+  @Override
+  public final Map<String, Object> value() {
+    final Map<String, Object> accum = new HashMap<>(0);
+    this.value
+      .forEach(
+        (key, val) -> accum.put(
+          key.replace('-', '.'),
+          val
+        )
+      );
+    return Collections.unmodifiableMap(accum);
+  }
+}

--- a/src/main/java/io/github/eocqrs/kafka/yaml/package-info.java
+++ b/src/main/java/io/github/eocqrs/kafka/yaml/package-info.java
@@ -1,0 +1,26 @@
+/*
+ *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/**
+ * YAML.
+ */
+package io.github.eocqrs.kafka.yaml;

--- a/src/test/java/io/github/eocqrs/kafka/act/AssignPartitionsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/act/AssignPartitionsTest.java
@@ -51,6 +51,9 @@ final class AssignPartitionsTest {
   ) {
     final Action assign =
       new AssignPartitions(mck, new TopicPartition("test", 1));
-    Assertions.assertDoesNotThrow(assign::apply);
+    Assertions.assertDoesNotThrow(
+        assign::apply,
+        () -> "Creates %s without any exceptions thrown".formatted(assign)
+    );
   }
 }

--- a/src/test/java/io/github/eocqrs/kafka/act/CommitAsyncTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/act/CommitAsyncTest.java
@@ -49,6 +49,9 @@ final class CommitAsyncTest {
     @Mock final KafkaConsumer<String, String> mck
   ) {
     final Action async = new CommitAsync(mck);
-    Assertions.assertDoesNotThrow(async::apply);
+    Assertions.assertDoesNotThrow(
+        async::apply,
+        () -> "Creates %s without any exceptions thrown".formatted(async)
+    );
   }
 }

--- a/src/test/java/io/github/eocqrs/kafka/act/CommitSyncTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/act/CommitSyncTest.java
@@ -49,6 +49,9 @@ final class CommitSyncTest {
     @Mock final KafkaConsumer<String, String> mck
   ) {
     final Action sync = new CommitSync(mck);
-    Assertions.assertDoesNotThrow(sync::apply);
+    Assertions.assertDoesNotThrow(
+        sync::apply,
+        () -> "Creates %s without any exceptions thrown".formatted(sync)
+    );
   }
 }

--- a/src/test/java/io/github/eocqrs/kafka/act/WakeupTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/act/WakeupTest.java
@@ -47,6 +47,9 @@ final class WakeupTest {
   @Test
   void wakeups(@Mock final KafkaConsumer<String, String> mck) {
     final Action wakeup = new Wakeup(mck);
-    Assertions.assertDoesNotThrow(wakeup::apply);
+    Assertions.assertDoesNotThrow(
+        wakeup::apply,
+        () -> "Creates %s without any exceptions thrown".formatted(wakeup)
+    );
   }
 }

--- a/src/test/java/io/github/eocqrs/kafka/consumer/settings/KfConsumerParamsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/consumer/settings/KfConsumerParamsTest.java
@@ -39,9 +39,10 @@ final class KfConsumerParamsTest {
   @Test
   void representsXmlCorrectly() {
     final Params mock = Mockito.mock(Params.class);
-    Mockito.when(mock.asXml()).thenReturn("<groupId>103</groupId>");
+    final String group = "<groupId>103</groupId>";
+    Mockito.when(mock.asXml()).thenReturn(group);
     MatcherAssert.assertThat(
-      "Represents right XML settings",
+      "Should return %s inside a consumer tag".formatted(group),
       new KfConsumerParams(mock).asXml(),
       Matchers.equalTo("<consumer>\n<groupId>103</groupId>\n</consumer>\n")
     );

--- a/src/test/java/io/github/eocqrs/kafka/fake/FkMetadataTaskTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/FkMetadataTaskTest.java
@@ -54,11 +54,10 @@ final class FkMetadataTaskTest {
       0
     );
     final Future<RecordMetadata> future =
-      new FkMetadataTask(
-        metadata
-      );
+      new FkMetadataTask(metadata);
     MatcherAssert.assertThat(
-      "Metadata in right format",
+      "Metadata %s in right format for %s"
+        .formatted(metadata, future.get()),
       future.get(),
       Matchers.equalTo(metadata)
     );

--- a/src/test/java/io/github/eocqrs/kafka/fake/FkRecordsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/FkRecordsTest.java
@@ -22,13 +22,11 @@
 
 package io.github.eocqrs.kafka.fake;
 
-import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.cactoos.list.ListOf;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Test;
-
-import java.util.function.Consumer;
 
 /**
  * Test case for {@link FkRecords}.
@@ -46,7 +44,8 @@ final class FkRecordsTest {
       .value()
       .forEach(rec ->
         MatcherAssert.assertThat(
-          "Records in right format",
+          "Values %s should contain the record %s"
+            .formatted(new ListOf<>(value), rec),
           rec.value(),
           Matchers.equalTo(value)
         ));
@@ -55,15 +54,17 @@ final class FkRecordsTest {
   @Test
   void readsCountInRightFormat() throws Exception {
     final String topic = "test";
+    final ConsumerRecords<Object, String> value = new FkRecords(
+      topic,
+      new ListOf<>(
+        "first",
+        "second"
+      )
+    ).value();
     MatcherAssert.assertThat(
-      "Records Count in right format",
-      new FkRecords(
-        topic,
-        new ListOf<>(
-          "first",
-          "second"
-        )
-      ).value().count(),
+      "Records %s size in equals 2"
+        .formatted(value),
+      value.count(),
       Matchers.equalTo(2)
     );
   }

--- a/src/test/java/io/github/eocqrs/kafka/fake/storage/InFileTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/fake/storage/InFileTest.java
@@ -28,6 +28,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.xembly.Directives;
 
+import static org.junit.jupiter.api.Assertions.assertAll;
+
 /**
  * Test case for {@link InFile}
  *
@@ -41,7 +43,7 @@ final class InFileTest {
   void createsStorageInXmlFile() throws Exception {
     final FkStorage storage = new InFile();
     MatcherAssert.assertThat(
-      "Storage has root <broker> tag",
+      "Storage %s has root <broker> tag".formatted(storage.xml()),
       storage.xml().nodes("broker").isEmpty(),
       Matchers.equalTo(false)
     );
@@ -56,7 +58,7 @@ final class InFileTest {
         .addIf("servers")
     );
     MatcherAssert.assertThat(
-      "XML has right format",
+      "Storage %s contains servers tag".formatted(storage.xml()),
       storage.xml().nodes("broker/servers").isEmpty(),
       Matchers.equalTo(false)
     );
@@ -65,11 +67,10 @@ final class InFileTest {
   @Test
   void locksAndUnlocks() throws Exception {
     final FkStorage storage = new InFile();
-    Assertions.assertDoesNotThrow(
-      storage::lock
-    );
-    Assertions.assertDoesNotThrow(
-      storage::unlock
+    assertAll(
+      () -> Assertions.assertDoesNotThrow(storage::lock),
+      () -> Assertions.assertDoesNotThrow(storage::unlock),
+      () -> "%s locks and unlocks without exceptions".formatted(storage.xml())
     );
   }
 }

--- a/src/test/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettingsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettingsTest.java
@@ -1,0 +1,46 @@
+/*
+ *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.yaml;
+
+import io.github.eocqrs.kafka.consumer.KfConsumer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test case for {@link KfYamlProducerSettings}.
+ */
+class KfYamlConsumerSettingsTest {
+
+  @Test
+  void createsConsumerFromYamlConfiguration() {
+    assertDoesNotThrow(
+      () ->
+        new KfConsumer<>(
+          new KfYamlConsumerSettings<>(
+            new YamlMapParams<String, String>("consumer.yaml")
+          )
+        )
+    );
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettingsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettingsTest.java
@@ -25,7 +25,7 @@ package io.github.eocqrs.kafka.yaml;
 import io.github.eocqrs.kafka.consumer.KfConsumer;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * Test case for {@link KfYamlProducerSettings}.

--- a/src/test/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettingsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettingsTest.java
@@ -1,0 +1,47 @@
+/*
+ *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.yaml;
+
+import io.github.eocqrs.kafka.producer.KfProducer;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Test case for {@link KfYamlConsumerSettings}.
+ */
+class KfYamlProducerSettingsTest {
+
+  @Test
+  void createsProducerFromYaml() {
+    assertDoesNotThrow(
+      () -> new KfProducer<>(
+        new KfYamlProducerSettings<>(
+          new YamlMapParams<String, String>(
+            "producer.yaml"
+          )
+        )
+      )
+    );
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettingsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettingsTest.java
@@ -25,7 +25,7 @@ package io.github.eocqrs.kafka.yaml;
 import io.github.eocqrs.kafka.producer.KfProducer;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 /**
  * Test case for {@link KfYamlConsumerSettings}.

--- a/src/test/java/io/github/eocqrs/kafka/yaml/YamlMapParamsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/yaml/YamlMapParamsTest.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright (c) 2022 Aliaksei Bialiauski, EO-CQRS
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package io.github.eocqrs.kafka.yaml;
+
+import org.cactoos.list.ListOf;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+
+/**
+ * Test case for {@link YamlMapParams}.
+ */
+final class YamlMapParamsTest {
+
+  /**
+   * Under test params.
+   */
+  private Map<String, Object> params;
+
+  @BeforeEach
+  void setParams() throws Exception {
+    this.params = new YamlMapParams<>("producer.yaml").value();
+  }
+
+  @Test
+  void createsMapProperly() {
+    final ListOf<String> actuals = new ListOf<>(
+      "bootstrap.servers",
+      "key.serializer",
+      "value.serializer"
+    );
+    assertAll(
+      () ->
+        MatcherAssert.assertThat(
+          "\nEvery key from \n\t%s\nShould be placed in \n\t%s"
+            .formatted(this.params.keySet(), actuals),
+          actuals,
+          Matchers.containsInAnyOrder(
+            this.params.keySet().toArray()
+          )
+        ),
+      () ->
+        actuals.forEach(
+          actual -> MatcherAssert.assertThat(
+            "\n%s\nContains value for each key from\n\t%s"
+              .formatted(this.params, actual),
+            this.params.get(actual),
+            Matchers.is(Matchers.notNullValue())
+          )
+        )
+    );
+  }
+
+  @Test
+  void throwsOnModification() {
+    assertThrows(
+      UnsupportedOperationException.class,
+      () -> this.params.put("key", new Object()),
+      "Must not modify \n\t%s".formatted(this.params)
+    );
+  }
+}

--- a/src/test/resources/consumer.yaml
+++ b/src/test/resources/consumer.yaml
@@ -1,0 +1,4 @@
+bootstrap-servers: localhost:9092
+group-id: "1"
+key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+value-deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/src/test/resources/producer.yaml
+++ b/src/test/resources/producer.yaml
@@ -1,0 +1,3 @@
+bootstrap-servers: localhost:9092
+key-serializer: org.apache.kafka.common.serialization.StringSerializer
+value-serializer: org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
closes #284

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding YAML configuration support for Kafka producer and consumer settings. 

### Detailed summary
- Added YAML configuration files for producer and consumer settings.
- Added dependencies for SnakeYAML.
- Updated code to read settings from YAML files.
- Added tests for YAML configuration.

> The following files were skipped due to too many changes: `src/test/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettingsTest.java`, `src/main/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettings.java`, `src/main/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettings.java`, `src/test/java/io/github/eocqrs/kafka/fake/FkProducerTest.java`, `src/test/java/io/github/eocqrs/kafka/yaml/YamlMapParamsTest.java`, `src/main/java/io/github/eocqrs/kafka/yaml/YamlMapParams.java`, `src/test/java/io/github/eocqrs/kafka/consumer/KfConsumerTest.java`, `src/test/java/io/github/eocqrs/kafka/fake/FkConsumerTest.java`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->