### PR TITLE
consumer/producer from yaml file name

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Since version `0.5.6` you can create Producer with YAML file:
 ```java
 final Producer<String, String> producer = new KfProducer<>(
   new KfYamlProducerSettings<>(
-    new YamlMapParams<String, String>("producer.yaml")
+    "producer.yaml"
   )
 );
 ```
@@ -270,7 +270,7 @@ Since version `0.5.6` you can create Consumer with YAML file:
 ```java
 final Consumer<String, String> consumer = new KfConsumer<>(
   new KfYamlConsumerSettings<>(
-    new YamlMapParams<String, String>("consumer.yaml")
+    "consumer.yaml"
   )
 );
 ```

--- a/README.md
+++ b/README.md
@@ -123,7 +123,9 @@ Or create it with XML file:
 ```java
 final Producer<String, String> producer =
   new KfProducer<>(
-    new KfXmlFlexible<String, String>("producer.xml") // file with producer config
+    new KfXmlFlexible<String, String>(
+      "producer.xml" // file with producer config
+    )
 );
 ```
 btw, your [XML](https://en.wikipedia.org/wiki/XML#:~:text=Extensible%20Markup%20Language%20(XML)%20is,%2Dreadable%20and%20machine%2Dreadable.) file should be in the ```resources``` look like:
@@ -139,7 +141,9 @@ Since version `0.4.6` you can create Producer with JSON file:
 ```java
 final Producer<String, String> producer =
   new KfProducer<>(
-  new KfJsonFlexible<String, String>("producer.json") // file with producer config  
+    new KfJsonFlexible<String, String>(
+      "producer.json" // file with producer config
+    )  
 );
 ```
 
@@ -154,9 +158,10 @@ Your [JSON](https://en.wikipedia.org/wiki/JSON), located in resources directory,
 
 Since version `0.5.6` you can create Producer with YAML file:
 ```java
-final Producer<String, String> producer = new KfProducer<>(
-  new KfYamlProducerSettings<>(
-    "producer.yaml"
+final Producer<String, String> producer =
+  new KfProducer<>(
+    new KfYamlProducerSettings<>(
+      "producer.yaml"
   )
 );
 ```
@@ -252,7 +257,9 @@ Since version `0.4.6` you can create Consumer with JSON file:
 ```java
 final Consumer<String, String> producer =
   new KfConsumer<>(
-  new KfJsonFlexible<String, String>("consumer.json") // file with producer config  
+    new KfJsonFlexible<String, String>(
+      "consumer.json" // file with producer config
+    )  
 );
 ```
 
@@ -268,10 +275,11 @@ Your [JSON](https://en.wikipedia.org/wiki/JSON), located in resources directory,
 
 Since version `0.5.6` you can create Consumer with YAML file:
 ```java
-final Consumer<String, String> consumer = new KfConsumer<>(
-  new KfYamlConsumerSettings<>(
-    "consumer.yaml"
-  )
+final Consumer<String, String> consumer = 
+  new KfConsumer<>(
+    new KfYamlConsumerSettings<>(
+      "consumer.yaml"
+    )
 );
 ```
 

--- a/src/main/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettings.java
+++ b/src/main/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettings.java
@@ -23,7 +23,6 @@
 package io.github.eocqrs.kafka.yaml;
 
 import io.github.eocqrs.kafka.ConsumerSettings;
-import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 /**
@@ -32,14 +31,32 @@ import org.apache.kafka.clients.consumer.KafkaConsumer;
  * @param <K> The key type.
  * @param <X> The value type.
  */
-@RequiredArgsConstructor
 public final class KfYamlConsumerSettings<K, X>
   implements ConsumerSettings<K, X> {
 
   /**
    * YAML params.
    */
-  private final YamlMapParams<K, X> params;
+  private final YamlMapParams params;
+
+  /**
+   * Ctor.
+   *
+   * @param prms YAML Params
+   */
+  public KfYamlConsumerSettings(final YamlMapParams prms) {
+    this.params = prms;
+  }
+
+  /**
+   * Ctor.
+   *
+   * @param nm YAML file name
+   * @throws Exception when something went wrong
+   */
+  public KfYamlConsumerSettings(final String nm) throws Exception {
+    this(new YamlMapParams(nm));
+  }
 
   @Override
   public KafkaConsumer<K, X> consumer() {

--- a/src/main/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettings.java
+++ b/src/main/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettings.java
@@ -23,7 +23,6 @@
 package io.github.eocqrs.kafka.yaml;
 
 import io.github.eocqrs.kafka.ProducerSettings;
-import lombok.RequiredArgsConstructor;
 import org.apache.kafka.clients.producer.KafkaProducer;
 
 /**
@@ -32,14 +31,32 @@ import org.apache.kafka.clients.producer.KafkaProducer;
  * @param <K> The key type.
  * @param <X> The value type.
  */
-@RequiredArgsConstructor
 public final class KfYamlProducerSettings<K, X>
   implements ProducerSettings<K, X> {
 
   /**
    * YAML params.
    */
-  private final YamlMapParams<K, X> params;
+  private final YamlMapParams params;
+
+  /**
+   * Ctor.
+   *
+   * @param prms YAML Params
+   */
+  public KfYamlProducerSettings(final YamlMapParams prms) {
+    this.params = prms;
+  }
+
+  /**
+   * Ctor.
+   *
+   * @param nm YAML file name
+   * @throws Exception when something went wrong
+   */
+  public KfYamlProducerSettings(final String nm) throws Exception {
+    this(new YamlMapParams(nm));
+  }
 
   @Override
   public KafkaProducer<K, X> producer() {

--- a/src/main/java/io/github/eocqrs/kafka/yaml/YamlMapParams.java
+++ b/src/main/java/io/github/eocqrs/kafka/yaml/YamlMapParams.java
@@ -36,12 +36,9 @@ import java.util.Map;
 /**
  * This class converts a YAML source from
  * kebab case keys into kafka specific keys Map.
- *
- * @param <K> The key type.
- * @param <X> The value type.
  */
 @RequiredArgsConstructor
-public class YamlMapParams<K, X> implements Scalar<Map<String, Object>> {
+public final class YamlMapParams implements Scalar<Map<String, Object>> {
 
   /**
    * The config value.
@@ -78,7 +75,7 @@ public class YamlMapParams<K, X> implements Scalar<Map<String, Object>> {
   }
 
   @Override
-  public final Map<String, Object> value() {
+  public Map<String, Object> value() {
     final Map<String, Object> accum = new HashMap<>(0);
     this.value
       .forEach(

--- a/src/test/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettingsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettingsTest.java
@@ -30,15 +30,29 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 /**
  * Test case for {@link KfYamlProducerSettings}.
  */
-class KfYamlConsumerSettingsTest {
+final class KfYamlConsumerSettingsTest {
 
   @Test
   void createsConsumerFromYamlConfiguration() {
     assertDoesNotThrow(
       () ->
-        new KfConsumer<>(
+        new KfConsumer<String, String>(
           new KfYamlConsumerSettings<>(
-            new YamlMapParams<String, String>("consumer.yaml")
+            new YamlMapParams(
+              "consumer.yaml"
+            )
+          )
+        )
+    );
+  }
+
+  @Test
+  void createsConsumerFromYamlFileName() {
+    assertDoesNotThrow(
+      () ->
+        new KfConsumer<String, String>(
+          new KfYamlConsumerSettings<>(
+            "consumer.yaml"
           )
         )
     );

--- a/src/test/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettingsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettingsTest.java
@@ -30,18 +30,30 @@ import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 /**
  * Test case for {@link KfYamlConsumerSettings}.
  */
-class KfYamlProducerSettingsTest {
+final class KfYamlProducerSettingsTest {
 
   @Test
-  void createsProducerFromYaml() {
+  void createsProducerFromYamlConfiguration() {
     assertDoesNotThrow(
-      () -> new KfProducer<>(
+      () -> new KfProducer<String, String>(
         new KfYamlProducerSettings<>(
-          new YamlMapParams<String, String>(
+          new YamlMapParams(
             "producer.yaml"
           )
         )
       )
+    );
+  }
+
+  @Test
+  void createsProducerFromYamlFileName() {
+    assertDoesNotThrow(
+      () ->
+        new KfProducer<String, String>(
+          new KfYamlProducerSettings<>(
+            "producer.yaml"
+          )
+        )
     );
   }
 }

--- a/src/test/java/io/github/eocqrs/kafka/yaml/YamlMapParamsTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/yaml/YamlMapParamsTest.java
@@ -46,7 +46,7 @@ final class YamlMapParamsTest {
 
   @BeforeEach
   void setParams() throws Exception {
-    this.params = new YamlMapParams<>("producer.yaml").value();
+    this.params = new YamlMapParams("producer.yaml").value();
   }
 
   @Test


### PR DESCRIPTION
closes #414 

<!-- start pr-codex -->

---

## PR-Codex overview
### Detailed summary
- Updated the constructor calls for `YamlMapParams` in `YamlMapParamsTest`, `KfYamlConsumerSettings`, and `KfYamlProducerSettings` classes.
- Changed the access modifier of `KfYamlConsumerSettingsTest` and `KfYamlProducerSettingsTest` classes to `final`.
- Added new test methods `createsConsumerFromYamlFileName` and `createsProducerFromYamlFileName` in `KfYamlConsumerSettingsTest` and `KfYamlProducerSettingsTest` classes respectively.
- Updated the code examples in the `README.md` file to reflect the changes in the constructor calls for `KfProducer` and `KfConsumer` classes.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->