### PR TITLE
416

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/KfTypified.java
+++ b/src/main/java/io/github/eocqrs/kafka/KfTypified.java
@@ -1,0 +1,14 @@
+package io.github.eocqrs.kafka;
+
+import io.github.eocqrs.kafka.auto.SupportedType;
+import org.cactoos.Scalar;
+
+import java.util.Map;
+
+public interface KfTypified extends Scalar<Map<String, Object>> {
+
+    SupportedType asType();
+
+    @Override
+    Map<String, Object> value();
+}

--- a/src/main/java/io/github/eocqrs/kafka/auto/AutoNames.java
+++ b/src/main/java/io/github/eocqrs/kafka/auto/AutoNames.java
@@ -1,0 +1,63 @@
+package io.github.eocqrs.kafka.auto;
+
+import lombok.SneakyThrows;
+import org.cactoos.Scalar;
+import org.cactoos.io.Directory;
+import org.cactoos.iterable.Filtered;
+import org.cactoos.iterable.IterableOf;
+import org.cactoos.list.ListOf;
+import org.cactoos.text.Upper;
+
+import java.io.File;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Collectors;
+
+public final class AutoNames implements Scalar<Map<Path, SupportedType>> {
+
+  private final String directory;
+
+  public AutoNames(final String directory) {
+    this.directory = directory;
+  }
+
+  @SneakyThrows
+  @Override
+  public Map<Path, SupportedType> value() {
+    return new ListOf<>(
+      new Filtered<>(
+        this::producerOrConsumerFile,
+        new IterableOf<>(
+          new Directory(
+            new File(
+              Objects.requireNonNull(
+                Thread.currentThread()
+                  .getContextClassLoader()
+                  .getResource("")
+              ).toURI()
+            )
+          ).iterator()
+        )
+      )
+    ).stream()
+      .collect(
+        Collectors.toMap(
+          path -> path,
+          path ->
+            SupportedType.valueOf(
+              new Upper(
+                new ExtensionOf(path).value()
+              ).toString()
+            )
+        )
+      );
+  }
+
+  private boolean producerOrConsumerFile(final Path path) {
+    return (path.getFileName().toString().contains("producer")
+      || path.getFileName().toString().contains("consumer"))
+      && path.toFile().isFile()
+      && path.getParent().endsWith(this.directory);
+  }
+}

--- a/src/main/java/io/github/eocqrs/kafka/auto/AutoNames.java
+++ b/src/main/java/io/github/eocqrs/kafka/auto/AutoNames.java
@@ -16,48 +16,41 @@ import java.util.stream.Collectors;
 
 public final class AutoNames implements Scalar<Map<Path, SupportedType>> {
 
-  private final String directory;
+    private final String directory;
 
-  public AutoNames(final String directory) {
-    this.directory = directory;
-  }
+    public AutoNames(final String directory) {
+        this.directory = directory;
+    }
 
-  @SneakyThrows
-  @Override
-  public Map<Path, SupportedType> value() {
-    return new ListOf<>(
-      new Filtered<>(
-        this::producerOrConsumerFile,
-        new IterableOf<>(
-          new Directory(
-            new File(
-              Objects.requireNonNull(
-                Thread.currentThread()
-                  .getContextClassLoader()
-                  .getResource("")
-              ).toURI()
+    @SneakyThrows
+    @Override
+    public Map<Path, SupportedType> value() {
+        return new ListOf<>(
+            new Filtered<>(
+                path -> new File(path.toUri()).isFile(),
+                new IterableOf<>(
+                    new Directory(
+                        Path.of(
+                            Objects.requireNonNull(
+                                Thread.currentThread()
+                                    .getContextClassLoader()
+                                    .getResource(this.directory)
+                            ).getPath()
+                        )
+                    ).iterator()
+                )
             )
-          ).iterator()
-        )
-      )
-    ).stream()
-      .collect(
-        Collectors.toMap(
-          path -> path,
-          path ->
-            SupportedType.valueOf(
-              new Upper(
-                new ExtensionOf(path).value()
-              ).toString()
-            )
-        )
-      );
-  }
-
-  private boolean producerOrConsumerFile(final Path path) {
-    return (path.getFileName().toString().contains("producer")
-      || path.getFileName().toString().contains("consumer"))
-      && path.toFile().isFile()
-      && path.getParent().endsWith(this.directory);
-  }
+        ).stream()
+            .collect(
+                Collectors.toMap(
+                    path -> path,
+                    path ->
+                        SupportedType.valueOf(
+                            new Upper(
+                                new ExtensionOf(path).value()
+                            ).toString()
+                        )
+                )
+            );
+    }
 }

--- a/src/main/java/io/github/eocqrs/kafka/auto/ExtensionOf.java
+++ b/src/main/java/io/github/eocqrs/kafka/auto/ExtensionOf.java
@@ -1,0 +1,24 @@
+package io.github.eocqrs.kafka.auto;
+
+import org.cactoos.Scalar;
+
+import java.nio.file.Path;
+
+public final class ExtensionOf implements Scalar<String> {
+  private final String filename;
+
+  public ExtensionOf(final Path path) {
+    this(path.toString());
+  }
+
+  public ExtensionOf(final String filename) {
+    this.filename = filename;
+  }
+
+  @Override
+  public String value() {
+    return this.filename.substring(
+      this.filename.lastIndexOf('.') + 1
+    );
+  }
+}

--- a/src/main/java/io/github/eocqrs/kafka/auto/ExtensionOf.java
+++ b/src/main/java/io/github/eocqrs/kafka/auto/ExtensionOf.java
@@ -5,20 +5,20 @@ import org.cactoos.Scalar;
 import java.nio.file.Path;
 
 public final class ExtensionOf implements Scalar<String> {
-  private final String filename;
+    private final String filename;
 
-  public ExtensionOf(final Path path) {
-    this(path.toString());
-  }
+    public ExtensionOf(final Path path) {
+        this(path.toString());
+    }
 
-  public ExtensionOf(final String filename) {
-    this.filename = filename;
-  }
+    public ExtensionOf(final String filename) {
+        this.filename = filename;
+    }
 
-  @Override
-  public String value() {
-    return this.filename.substring(
-      this.filename.lastIndexOf('.') + 1
-    );
-  }
+    @Override
+    public String value() {
+        return this.filename.substring(
+            this.filename.lastIndexOf('.') + 1
+        );
+    }
 }

--- a/src/main/java/io/github/eocqrs/kafka/auto/KfAuto.java
+++ b/src/main/java/io/github/eocqrs/kafka/auto/KfAuto.java
@@ -1,72 +1,31 @@
 package io.github.eocqrs.kafka.auto;
 
 import io.github.eocqrs.kafka.ConsumerSettings;
+import io.github.eocqrs.kafka.KfTypified;
 import io.github.eocqrs.kafka.ProducerSettings;
-import io.github.eocqrs.kafka.xml.ConsumerXmlMapParams;
-import io.github.eocqrs.kafka.yaml.YamlMapParams;
-import lombok.SneakyThrows;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.KafkaProducer;
-import org.cactoos.Scalar;
 
-import java.nio.file.Path;
-import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 public final class KfAuto<K, X>
-  implements ConsumerSettings<K, X>, ProducerSettings<K, X> {
+    implements ConsumerSettings<K, X>, ProducerSettings<K, X> {
 
-  private final Map<Path, SupportedType> consumersParams;
+    private final AutoNames names;
+    private final Stream<KfTypified> params;
 
-  private final Map<Path, SupportedType> producersParams;
+    public KfAuto(final AutoNames names, final KfTypified... params) {
+        this.names = names;
+        this.params = Stream.of(params);
+    }
 
-  private final Map<SupportedType, Scalar<Map<String, Object>>> consumers;
+    @Override
+    public KafkaConsumer<K, X> consumer() {
+        return null;
+    }
 
-  private final Map<SupportedType, Map<String, Object>> producers;
-
-  @SneakyThrows
-  public KfAuto(final AutoNames names) {
-    this.consumers = Map.of(
-      SupportedType.YAML, new YamlMapParams("consumer.yaml"),
-      SupportedType.XML, new ConsumerXmlMapParams("consumer.xml")
-    );
-    this.producers = Map.of(
-      SupportedType.YAML, new YamlMapParams("producer.yaml").value()
-    );
-    this.consumersParams = KfAuto.ejectParams(names, "consumer");
-    this.producersParams = KfAuto.ejectParams(names, "producer");
-  }
-
-  private static Map<Path, SupportedType> ejectParams(final AutoNames names, final String producer) {
-    return names.value()
-      .entrySet()
-      .stream()
-      .filter(pathType -> pathType.getKey().toString().contains(producer))
-      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-  }
-
-  @Override
-  public KafkaConsumer<K, X> consumer() {
-    return this.consumersParams.entrySet()
-      .stream()
-      .map(
-        pathType -> {
-          try {
-            return new KafkaConsumer<K, X>(
-              this.consumers.get(
-                pathType.getValue()
-              ).value()
-            );
-          } catch (final Exception e) {
-            throw new RuntimeException(e);
-          }
-        }
-      ).findAny()
-      .orElseThrow();
-  }
-
-  @Override
-  public KafkaProducer<K, X> producer() {
-    return null;
-  }
+    @Override
+    public KafkaProducer<K, X> producer() {
+        return null;
+    }
 }

--- a/src/main/java/io/github/eocqrs/kafka/auto/KfAuto.java
+++ b/src/main/java/io/github/eocqrs/kafka/auto/KfAuto.java
@@ -1,0 +1,72 @@
+package io.github.eocqrs.kafka.auto;
+
+import io.github.eocqrs.kafka.ConsumerSettings;
+import io.github.eocqrs.kafka.ProducerSettings;
+import io.github.eocqrs.kafka.xml.ConsumerXmlMapParams;
+import io.github.eocqrs.kafka.yaml.YamlMapParams;
+import lombok.SneakyThrows;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.cactoos.Scalar;
+
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+public final class KfAuto<K, X>
+  implements ConsumerSettings<K, X>, ProducerSettings<K, X> {
+
+  private final Map<Path, SupportedType> consumersParams;
+
+  private final Map<Path, SupportedType> producersParams;
+
+  private final Map<SupportedType, Scalar<Map<String, Object>>> consumers;
+
+  private final Map<SupportedType, Map<String, Object>> producers;
+
+  @SneakyThrows
+  public KfAuto(final AutoNames names) {
+    this.consumers = Map.of(
+      SupportedType.YAML, new YamlMapParams("consumer.yaml"),
+      SupportedType.XML, new ConsumerXmlMapParams("consumer.xml")
+    );
+    this.producers = Map.of(
+      SupportedType.YAML, new YamlMapParams("producer.yaml").value()
+    );
+    this.consumersParams = KfAuto.ejectParams(names, "consumer");
+    this.producersParams = KfAuto.ejectParams(names, "producer");
+  }
+
+  private static Map<Path, SupportedType> ejectParams(final AutoNames names, final String producer) {
+    return names.value()
+      .entrySet()
+      .stream()
+      .filter(pathType -> pathType.getKey().toString().contains(producer))
+      .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  @Override
+  public KafkaConsumer<K, X> consumer() {
+    return this.consumersParams.entrySet()
+      .stream()
+      .map(
+        pathType -> {
+          try {
+            return new KafkaConsumer<K, X>(
+              this.consumers.get(
+                pathType.getValue()
+              ).value()
+            );
+          } catch (final Exception e) {
+            throw new RuntimeException(e);
+          }
+        }
+      ).findAny()
+      .orElseThrow();
+  }
+
+  @Override
+  public KafkaProducer<K, X> producer() {
+    return null;
+  }
+}

--- a/src/main/java/io/github/eocqrs/kafka/auto/KfTypifiedEnvelope.java
+++ b/src/main/java/io/github/eocqrs/kafka/auto/KfTypifiedEnvelope.java
@@ -1,0 +1,34 @@
+package io.github.eocqrs.kafka.auto;
+
+import io.github.eocqrs.kafka.KfTypified;
+import lombok.SneakyThrows;
+import org.cactoos.Scalar;
+
+import java.util.Collections;
+import java.util.Map;
+
+public abstract class KfTypifiedEnvelope implements KfTypified {
+
+    private final Scalar<Map<String, Object>> origin;
+    private final SupportedType type;
+
+    protected KfTypifiedEnvelope(
+        final Scalar<Map<String, Object>> origin,
+        final SupportedType type
+    ) {
+        this.origin = origin;
+        this.type = type;
+    }
+
+    @Override
+    public final SupportedType asType() {
+        return this.type;
+    }
+
+    @SneakyThrows
+    @Override
+    public final Map<String, Object> value() {
+        return Collections
+            .unmodifiableMap(this.origin.value());
+    }
+}

--- a/src/main/java/io/github/eocqrs/kafka/auto/KfTypifiedXmlParams.java
+++ b/src/main/java/io/github/eocqrs/kafka/auto/KfTypifiedXmlParams.java
@@ -1,0 +1,12 @@
+package io.github.eocqrs.kafka.auto;
+
+import org.cactoos.Scalar;
+
+import java.util.Map;
+
+public class KfTypifiedXmlParams extends KfTypifiedEnvelope {
+
+    public KfTypifiedXmlParams(final Scalar<Map<String, Object>> params) {
+        super(params, SupportedType.XML);
+    }
+}

--- a/src/main/java/io/github/eocqrs/kafka/auto/KfTypifiedYamlParams.java
+++ b/src/main/java/io/github/eocqrs/kafka/auto/KfTypifiedYamlParams.java
@@ -1,0 +1,15 @@
+package io.github.eocqrs.kafka.auto;
+
+import org.cactoos.Scalar;
+
+import java.util.Map;
+
+/**
+ * @todo #416 Default params when passed is empty
+ */
+public class KfTypifiedYamlParams extends KfTypifiedEnvelope {
+
+    public KfTypifiedYamlParams(final Scalar<Map<String, Object>> params) {
+        super(params, SupportedType.YAML);
+    }
+}

--- a/src/main/java/io/github/eocqrs/kafka/auto/SupportedType.java
+++ b/src/main/java/io/github/eocqrs/kafka/auto/SupportedType.java
@@ -1,17 +1,17 @@
 package io.github.eocqrs.kafka.auto;
 
 public enum SupportedType {
-  YAML("yaml"), JSON("json"), XML("xml");
+    YAML("yaml"), JSON("json"), XML("xml");
 
-  private final String name;
+    private final String name;
 
-  SupportedType(final String name) {
-    this.name = name;
-  }
+    SupportedType(final String name) {
+        this.name = name;
+    }
 
 
-  @Override
-  public final String toString() {
-    return this.name;
-  }
+    @Override
+    public final String toString() {
+        return this.name;
+    }
 }

--- a/src/main/java/io/github/eocqrs/kafka/auto/SupportedType.java
+++ b/src/main/java/io/github/eocqrs/kafka/auto/SupportedType.java
@@ -1,0 +1,17 @@
+package io.github.eocqrs.kafka.auto;
+
+public enum SupportedType {
+  YAML("yaml"), JSON("json"), XML("xml");
+
+  private final String name;
+
+  SupportedType(final String name) {
+    this.name = name;
+  }
+
+
+  @Override
+  public final String toString() {
+    return this.name;
+  }
+}

--- a/src/main/java/io/github/eocqrs/kafka/xml/ConsumerXmlMapParams.java
+++ b/src/main/java/io/github/eocqrs/kafka/xml/ConsumerXmlMapParams.java
@@ -48,7 +48,7 @@ public final class ConsumerXmlMapParams extends XmlMapParams {
    * @param resource The resource with xml settings.
    * @throws Exception When something went wrong.
    */
-  ConsumerXmlMapParams(final Input resource) throws Exception {
+  public ConsumerXmlMapParams(final Input resource) throws Exception {
     super(resource, KfCustomer.CONSUMER);
   }
 
@@ -58,7 +58,7 @@ public final class ConsumerXmlMapParams extends XmlMapParams {
    * @param name Name of the resource.
    * @throws Exception When something went wrong.
    */
-  ConsumerXmlMapParams(final String name) throws Exception {
+  public ConsumerXmlMapParams(final String name) throws Exception {
     super(name, KfCustomer.CONSUMER);
   }
 }

--- a/src/main/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettings.java
+++ b/src/main/java/io/github/eocqrs/kafka/yaml/KfYamlConsumerSettings.java
@@ -23,6 +23,7 @@
 package io.github.eocqrs.kafka.yaml;
 
 import io.github.eocqrs.kafka.ConsumerSettings;
+import lombok.SneakyThrows;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 
 /**

--- a/src/main/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettings.java
+++ b/src/main/java/io/github/eocqrs/kafka/yaml/KfYamlProducerSettings.java
@@ -23,6 +23,7 @@
 package io.github.eocqrs.kafka.yaml;
 
 import io.github.eocqrs.kafka.ProducerSettings;
+import lombok.SneakyThrows;
 import org.apache.kafka.clients.producer.KafkaProducer;
 
 /**

--- a/src/test/java/io/github/eocqrs/kafka/auto/AutoNamesTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/auto/AutoNamesTest.java
@@ -1,0 +1,25 @@
+package io.github.eocqrs.kafka.auto;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+import java.util.stream.Stream;
+
+final class AutoNamesTest {
+
+    @Test
+    void scansDirectories() {
+        Stream.of("xml", "yaml")
+            .map(AutoNames::new)
+            .forEach(
+                names ->
+                    MatcherAssert.assertThat(
+                        "'%s'\n\tShould have two files inside"
+                            .formatted(names.value()),
+                        names.value().keySet(),
+                        Matchers.hasSize(2)
+                    )
+            );
+    }
+}

--- a/src/test/java/io/github/eocqrs/kafka/auto/KfAutoTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/auto/KfAutoTest.java
@@ -1,0 +1,24 @@
+package io.github.eocqrs.kafka.auto;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+
+final class KfAutoTest {
+
+  @Test
+  void createsAuto() {
+    assertAll(() -> {
+        for (int i = 0; i < 10; i++) {
+          assertDoesNotThrow(
+            () -> new KfAuto<String, String>(
+              new AutoNames("xml")
+            ).consumer()
+          );
+        }
+      }
+
+    );
+  }
+}

--- a/src/test/java/io/github/eocqrs/kafka/auto/KfAutoTest.java
+++ b/src/test/java/io/github/eocqrs/kafka/auto/KfAutoTest.java
@@ -2,23 +2,9 @@ package io.github.eocqrs.kafka.auto;
 
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertAll;
-import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
-
 final class KfAutoTest {
 
   @Test
   void createsAuto() {
-    assertAll(() -> {
-        for (int i = 0; i < 10; i++) {
-          assertDoesNotThrow(
-            () -> new KfAuto<String, String>(
-              new AutoNames("xml")
-            ).consumer()
-          );
-        }
-      }
-
-    );
   }
 }

--- a/src/test/resources/xml/consumer.xml
+++ b/src/test/resources/xml/consumer.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+MIT License
+
+Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<consumer>
+  <bootstrapServers>localhost:9092</bootstrapServers>
+  <groupId>1</groupId>
+  <keyDeserializer>org.apache.kafka.common.serialization.StringDeserializer</keyDeserializer>
+  <valueDeserializer>org.apache.kafka.common.serialization.StringDeserializer</valueDeserializer>
+</consumer>

--- a/src/test/resources/xml/producer.xml
+++ b/src/test/resources/xml/producer.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+MIT License
+
+Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+-->
+<producer>
+  <bootstrapServers>test</bootstrapServers>
+  <keySerializer>org.apache.kafka.common.serialization.StringSerializer</keySerializer>
+  <valueSerializer>org.apache.kafka.common.serialization.StringSerializer</valueSerializer>
+</producer>

--- a/src/test/resources/yaml/consumer.yaml
+++ b/src/test/resources/yaml/consumer.yaml
@@ -1,0 +1,26 @@
+# MIT License
+#
+# Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+bootstrap-servers: localhost:9092
+group-id: "1"
+key-deserializer: org.apache.kafka.common.serialization.StringDeserializer
+value-deserializer: org.apache.kafka.common.serialization.StringDeserializer

--- a/src/test/resources/yaml/producer.yaml
+++ b/src/test/resources/yaml/producer.yaml
@@ -1,0 +1,25 @@
+# MIT License
+#
+# Copyright (c) 2023 Aliaksei Bialiauski, EO-CQRS
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NON-INFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+bootstrap-servers: localhost:9092
+key-serializer: org.apache.kafka.common.serialization.StringSerializer
+value-serializer: org.apache.kafka.common.serialization.StringSerializer


### PR DESCRIPTION
closes #416

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on adding auto-generated Kafka consumer and producer settings based on YAML and XML files. 

### Detailed summary
- Added `KfAutoTest` class with a test method `createsAuto`.
- Added `KfYamlConsumerSettings` class with imports and `@SneakyThrows` annotation.
- Added `KfYamlProducerSettings` class with imports and `@SneakyThrows` annotation.
- Added `KfTypified` interface with `asType` and `value` methods.
- Added `SupportedType` enum with `toString` method.
- Added `KfTypifiedXmlParams` class with imports.
- Added `KfTypifiedYamlParams` class with imports and a TODO comment.
- Added `ExtensionOf` class with imports.
- Added `AutoNamesTest` class with a test method `scansDirectories`.
- Modified `ConsumerXmlMapParams` constructor visibility.
- Added `KfTypifiedEnvelope` class with imports and methods.
- Added `KfAuto` class with imports and methods.
- Added `AutoNames` class with imports and methods.
- Added YAML and XML files in the `src/test/resources` directory.

> The following files were skipped due to too many changes: `src/test/resources/xml/consumer.xml`

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->