### PR TITLE
cached messages

### DIFF
--- a/src/main/java/io/github/eocqrs/kafka/Message.java
+++ b/src/main/java/io/github/eocqrs/kafka/Message.java
@@ -35,6 +35,4 @@ import org.cactoos.Scalar;
  */
 public interface Message<K, X> extends Scalar<ProducerRecord<K, X>> {
 
-  @Override
-  ProducerRecord<K, X> value() throws Exception;
 }

--- a/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
@@ -25,6 +25,7 @@ package io.github.eocqrs.kafka.data;
 import io.github.eocqrs.kafka.Message;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Synced;
 
 /**
  * Message with timestamp.
@@ -43,7 +44,7 @@ public final class Timestamped<K, X> implements Message<K, X> {
   /**
    * Message.
    */
-  private final Sticky<ProducerRecord<K, X>> message;
+  private final Synced<ProducerRecord<K, X>> message;
 
   /**
    * Ctor.
@@ -56,7 +57,7 @@ public final class Timestamped<K, X> implements Message<K, X> {
     final Message<K, X> msg
   ) {
     this.timestamp = tmstmp;
-    this.message = new Sticky<>(msg);
+    this.message = new Synced<>(new Sticky<>(msg));
   }
 
   @Override

--- a/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
@@ -43,7 +43,7 @@ public final class Timestamped<K, X> implements Message<K, X> {
   private final long timestamp;
 
   /*
-   * @todo #428:60min/DEV Write tests for caching mechanism.
+   * @todo #428:60min/DEV Write tests for Timestamped caching mechanism.
    *   We need to prove with tests that our caching works
    *   and that it is also thread-safe.
    * */

--- a/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
@@ -24,6 +24,7 @@ package io.github.eocqrs.kafka.data;
 
 import io.github.eocqrs.kafka.Message;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.cactoos.scalar.Sticky;
 
 /**
  * Message with timestamp.
@@ -42,7 +43,7 @@ public final class Timestamped<K, X> implements Message<K, X> {
   /**
    * Message.
    */
-  private final Message<K, X> message;
+  private final Sticky<ProducerRecord<K, X>> message;
 
   /**
    * Ctor.
@@ -55,7 +56,7 @@ public final class Timestamped<K, X> implements Message<K, X> {
     final Message<K, X> msg
   ) {
     this.timestamp = tmstmp;
-    this.message = msg;
+    this.message = new Sticky<>(msg);
   }
 
   @Override

--- a/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
@@ -41,14 +41,15 @@ public final class Timestamped<K, X> implements Message<K, X> {
    * Timestamp.
    */
   private final long timestamp;
-  /**
-   * Message.
-   */
+
   /*
    * @todo #428:60min/DEV Write tests for caching mechanism.
    *   We need to prove with tests that our caching works
    *   and that it is also thread-safe.
    * */
+  /**
+   * Message.
+   */
   private final Synced<ProducerRecord<K, X>> message;
 
   /**

--- a/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
@@ -24,6 +24,7 @@ package io.github.eocqrs.kafka.data;
 
 import io.github.eocqrs.kafka.Message;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.cactoos.Scalar;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Synced;
 
@@ -50,7 +51,7 @@ public final class Timestamped<K, X> implements Message<K, X> {
   /**
    * Message.
    */
-  private final Synced<ProducerRecord<K, X>> message;
+  private final Scalar<ProducerRecord<K, X>> message;
 
   /**
    * Ctor.

--- a/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/Timestamped.java
@@ -44,6 +44,11 @@ public final class Timestamped<K, X> implements Message<K, X> {
   /**
    * Message.
    */
+  /*
+   * @todo #428:60min/DEV Write tests for caching mechanism.
+   *   We need to prove with tests that our caching works
+   *   and that it is also thread-safe.
+   * */
   private final Synced<ProducerRecord<K, X>> message;
 
   /**

--- a/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
@@ -25,6 +25,7 @@ package io.github.eocqrs.kafka.data;
 import io.github.eocqrs.kafka.Message;
 import org.apache.kafka.clients.producer.ProducerRecord;
 import org.cactoos.scalar.Sticky;
+import org.cactoos.scalar.Synced;
 
 /**
  * Message with specified partition.
@@ -43,7 +44,7 @@ public final class WithPartition<K, X> implements Message<K, X> {
   /**
    * Message.
    */
-  private final Sticky<ProducerRecord<K, X>> message;
+  private final Synced<ProducerRecord<K, X>> message;
 
   /**
    * Ctor.
@@ -56,7 +57,7 @@ public final class WithPartition<K, X> implements Message<K, X> {
     final Message<K, X> msg
   ) {
     this.partition = prtn;
-    this.message = new Sticky<>(msg);
+    this.message = new Synced<>(new Sticky<>(msg));
   }
 
   @Override

--- a/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
@@ -44,6 +44,11 @@ public final class WithPartition<K, X> implements Message<K, X> {
   /**
    * Message.
    */
+  /*
+  * @todo #428:60min/DEV Write tests for caching mechanism.
+  *   We need to prove with tests that our caching works
+  *   and that it is also thread-safe.
+  * */
   private final Synced<ProducerRecord<K, X>> message;
 
   /**

--- a/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
@@ -43,7 +43,7 @@ public final class WithPartition<K, X> implements Message<K, X> {
   private final int partition;
 
   /*
-   * @todo #428:60min/DEV Write tests for caching mechanism.
+   * @todo #428:60min/DEV Write tests for WithPartition caching mechanism.
    *   We need to prove with tests that our caching works
    *   and that it is also thread-safe.
    * */

--- a/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
@@ -24,6 +24,7 @@ package io.github.eocqrs.kafka.data;
 
 import io.github.eocqrs.kafka.Message;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.cactoos.scalar.Sticky;
 
 /**
  * Message with specified partition.
@@ -42,7 +43,7 @@ public final class WithPartition<K, X> implements Message<K, X> {
   /**
    * Message.
    */
-  private final Message<K, X> message;
+  private final Sticky<ProducerRecord<K, X>> message;
 
   /**
    * Ctor.
@@ -55,7 +56,7 @@ public final class WithPartition<K, X> implements Message<K, X> {
     final Message<K, X> msg
   ) {
     this.partition = prtn;
-    this.message = msg;
+    this.message = new Sticky<>(msg);
   }
 
   @Override

--- a/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
@@ -41,14 +41,15 @@ public final class WithPartition<K, X> implements Message<K, X> {
    * Partition.
    */
   private final int partition;
+
+  /*
+   * @todo #428:60min/DEV Write tests for caching mechanism.
+   *   We need to prove with tests that our caching works
+   *   and that it is also thread-safe.
+   * */
   /**
    * Message.
    */
-  /*
-  * @todo #428:60min/DEV Write tests for caching mechanism.
-  *   We need to prove with tests that our caching works
-  *   and that it is also thread-safe.
-  * */
   private final Synced<ProducerRecord<K, X>> message;
 
   /**

--- a/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
+++ b/src/main/java/io/github/eocqrs/kafka/data/WithPartition.java
@@ -24,6 +24,7 @@ package io.github.eocqrs.kafka.data;
 
 import io.github.eocqrs.kafka.Message;
 import org.apache.kafka.clients.producer.ProducerRecord;
+import org.cactoos.Scalar;
 import org.cactoos.scalar.Sticky;
 import org.cactoos.scalar.Synced;
 
@@ -50,7 +51,7 @@ public final class WithPartition<K, X> implements Message<K, X> {
   /**
    * Message.
    */
-  private final Synced<ProducerRecord<K, X>> message;
+  private final Scalar<ProducerRecord<K, X>> message;
 
   /**
    * Ctor.

--- a/src/main/java/io/github/eocqrs/kafka/xml/XmlMapParams.java
+++ b/src/main/java/io/github/eocqrs/kafka/xml/XmlMapParams.java
@@ -44,7 +44,7 @@ import java.util.stream.Collectors;
 abstract class XmlMapParams implements Scalar<Map<String, Object>> {
 
   /**
-   * It's a regex that matches all capital letters, except the first one.
+   * It's a regex that matches all capital letters except the first one.
    */
   private static final Pattern CAPITALS = Pattern.compile("(?<!^)([A-Z])");
 


### PR DESCRIPTION
closes #428 

@h1alexbel take a look, please

<!-- start pr-codex -->

---

## PR-Codex overview
This PR focuses on improving the caching mechanism in the `Timestamped` and `WithPartition` classes. 

### Detailed summary
- Added imports for `Scalar`, `Sticky`, and `Synced`
- Changed the type of the `message` field in `Timestamped` and `WithPartition` to `Scalar<ProducerRecord<K, X>>`
- Updated the constructor of `Timestamped` and `WithPartition` to use `Synced` and `Sticky` for caching
- Added a todo comment to write tests for the caching mechanism in both classes

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->