### PR TITLE
pdd fixed

### DIFF
--- a/.github/workflows/pdd.yml
+++ b/.github/workflows/pdd.yml
@@ -11,4 +11,4 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
-      - uses: g4s8/pdd-action@master
+      - uses: volodya-lombrozo/pdd-action@master


### PR DESCRIPTION
<!-- start pr-codex -->

## PR-Codex overview
This PR updates the PDD GitHub Action to use the `volodya-lombrozo/pdd-action` repository instead of `g4s8/pdd-action`.

### Detailed summary
- Updated the PDD GitHub Action to use `volodya-lombrozo/pdd-action` repository instead of `g4s8/pdd-action`.

> ✨ Ask PR-Codex anything about this PR by commenting with `/codex {your question}`

<!-- end pr-codex -->